### PR TITLE
zwo_asi_driver: fix enumeration of cameras

### DIFF
--- a/src/drivers/zwo_asi/zwo_asi_driver.cpp
+++ b/src/drivers/zwo_asi/zwo_asi_driver.cpp
@@ -20,6 +20,7 @@
 #include "ASICamera2.h"
 #include "zwo_asi_imager.h"
 #include "zwoexception.h"
+#include <QDebug>
 
 using namespace std;
 
@@ -69,7 +70,8 @@ Driver::Cameras ZWO_ASI_Driver::cameras() const
   int index=0;
   for(int index=0; index<ncams; index++) {
     ASI_CAMERA_INFO info;
-    ASI_CHECK << ASIGetCameraProperty(&info, index++) << string{"Get Camera Property"};
+    ASI_CHECK << ASIGetCameraProperty(&info, index) << string{"Get Camera Property"};
+    qDebug() << "ZWO camera index" << index << "is a" << info.Name;
     cameras.push_back(make_shared<ZWO_ASI_Camera>(info));
   }
   return cameras;


### PR DESCRIPTION
Hi,
When having two ASI camera, only the first was listed in the connection menu.
Digging into zwo_asi_driver, I figured out that index should not be incremented inside the for loop.
In addition, I added one line to the debug log.
BR,
chrillomat