### PR TITLE
Pass Configuration by reference instead of shared_ptr; fixes the crash in ConfigurationDialog

### DIFF
--- a/src/commons/configuration.h
+++ b/src/commons/configuration.h
@@ -27,7 +27,6 @@ class Configuration : public QObject
 {
   Q_OBJECT
 public:
-    typedef std::shared_ptr<Configuration> ptr;
     Configuration();
     ~Configuration();
 #define declare_setting(name, type) \

--- a/src/image_handlers/backend/local_saveimages.cpp
+++ b/src/image_handlers/backend/local_saveimages.cpp
@@ -45,7 +45,7 @@ class WriterThreadWorker;
 };
 
 DPTR_IMPL(LocalSaveImages) {
-    Configuration::ptr configuration;
+    Configuration &configuration;
     WriterThreadWorker *worker;
     QThread *recordingThread;
     LocalSaveImages *q;
@@ -68,7 +68,7 @@ struct RecordingParameters {
   int64_t max_size;
   bool timelapse;
   qlonglong timelapse_msecs;
-  Configuration::ptr configuration;
+  Configuration *configuration = nullptr;
   RecordingInformation::Writer::ptr recording_information_writer(const FileWriter::Ptr &file_writer) const;
 };
 
@@ -77,7 +77,7 @@ RecordingInformation::Writer::ptr RecordingParameters::recording_information_wri
   if(write_txt_info)
     writers.push_back(RecordingInformation::txt(file_writer->filename()));
   if(write_json_info)
-    writers.push_back(RecordingInformation::json(file_writer->filename(), configuration));
+    writers.push_back(RecordingInformation::json(file_writer->filename(), *configuration));
   return RecordingInformation::composite(writers);
 }
 
@@ -264,14 +264,14 @@ void WriterThreadWorker::start(const RecordingParameters & recording_parameters,
 
 FileWriter::Factory LocalSaveImages::Private::writerFactory()
 {
-  if(configuration->savefile().isEmpty()) {
+  if(configuration.savefile().isEmpty()) {
     return {};
   }
 
-  return FileWriter::factories()[configuration->save_format()];
+  return FileWriter::factories()[configuration.save_format()];
 }
 
-LocalSaveImages::LocalSaveImages(const Configuration::ptr & configuration, QObject* parent)
+LocalSaveImages::LocalSaveImages(Configuration &configuration, QObject* parent)
   : dptr(configuration, new WriterThreadWorker(this), new QThread, this)
 {
   d->worker->moveToThread(d->recordingThread);
@@ -298,21 +298,21 @@ void LocalSaveImages::startRecording(Imager *imager)
   auto writerFactory = d->writerFactory();
   if(writerFactory) {
     RecordingInformation::ptr recording_information;
-    
+
     RecordingParameters recording{
-      bind(writerFactory, imager->name(), d->configuration), 
+      bind(writerFactory, imager->name(), &d->configuration),
       make_shared<RecordingInformation>(d->configuration, imager),
-      d->configuration->recording_limit_type(),
-      d->configuration->recording_frames_limit(),
-      chrono::duration<double>{d->configuration->recording_seconds_limit()},
-      d->configuration->save_info_file(),
-      d->configuration->save_json_info_file(),
+      d->configuration.recording_limit_type(),
+      d->configuration.recording_frames_limit(),
+      chrono::duration<double>{d->configuration.recording_seconds_limit()},
+      d->configuration.save_info_file(),
+      d->configuration.save_json_info_file(),
       0,
-      d->configuration->timelapse_mode(),
-      d->configuration->timelapse_msecs(),
-      d->configuration
-    };    
-    QMetaObject::invokeMethod(d->worker, "start", Q_ARG(RecordingParameters, recording), Q_ARG(qlonglong, d->configuration->max_memory_usage() ));    
+      d->configuration.timelapse_mode(),
+      d->configuration.timelapse_msecs(),
+      &d->configuration
+    };
+    QMetaObject::invokeMethod(d->worker, "start", Q_ARG(RecordingParameters, recording), Q_ARG(qlonglong, d->configuration.max_memory_usage() ));
   }
 }
 

--- a/src/image_handlers/backend/local_saveimages.h
+++ b/src/image_handlers/backend/local_saveimages.h
@@ -27,7 +27,7 @@ class LocalSaveImages : public SaveImages
 {
   Q_OBJECT
 public:
-    LocalSaveImages(const Configuration::ptr &configuration, QObject *parent = 0);
+    LocalSaveImages(Configuration &configuration, QObject *parent = 0);
     ~LocalSaveImages();
     virtual void handle(const Frame::ptr &frame);
 public slots:

--- a/src/image_handlers/backend/recordinginformation.cpp
+++ b/src/image_handlers/backend/recordinginformation.cpp
@@ -34,12 +34,12 @@ DPTR_IMPL(RecordingInformation) {
   QVariantMap properties;
 };
 
-RecordingInformation::RecordingInformation(const Configuration::ptr & configuration, Imager *imager) : dptr(QDateTime::currentDateTime())
+RecordingInformation::RecordingInformation(const Configuration &configuration, Imager *imager) : dptr(QDateTime::currentDateTime())
 {
   d->properties["started"] = d->started.toString(Qt::ISODate);
   d->properties["camera"] = imager->name();
-  d->properties["observer"] = configuration->observer();
-  d->properties["telescope"] = configuration->telescope();
+  d->properties["observer"] = configuration.observer();
+  d->properties["telescope"] = configuration.telescope();
   QVariantList controls;
   for(auto control: imager->controls()) {
     controls.push_back(control.asMap());
@@ -75,12 +75,12 @@ RecordingInformation::~RecordingInformation()
 namespace {
   class JSONRecordingInformationWriter : public RecordingInformation::Writer {
   public:
-    JSONRecordingInformationWriter(const QString &file_base_name, const Configuration::ptr &configuration);
+    JSONRecordingInformationWriter(const QString &file_base_name, Configuration &configuration);
     virtual void write(const QVariantMap &information);
     ~JSONRecordingInformationWriter();
   private:
     const QString file_base_name;
-    Configuration::ptr configuration;
+    Configuration &configuration;
   };
   
   class TXTRecordingInformationWriter : public RecordingInformation::Writer {
@@ -131,7 +131,7 @@ namespace {
   }
 }
 
-JSONRecordingInformationWriter::JSONRecordingInformationWriter(const QString &file_base_name, const Configuration::ptr &configuration) 
+JSONRecordingInformationWriter::JSONRecordingInformationWriter(const QString &file_base_name, Configuration &configuration)
   : file_base_name{file_base_name}, configuration{configuration} {
 }
 
@@ -141,7 +141,7 @@ void JSONRecordingInformationWriter::write(const QVariantMap &information) {
 }
 
 JSONRecordingInformationWriter::~JSONRecordingInformationWriter() {
-  QMetaObject::invokeMethod(configuration.get(), "recording_preset_saved", Q_ARG(QString, "%1.json"_q % file_base_name));
+  QMetaObject::invokeMethod(&configuration, "recording_preset_saved", Q_ARG(QString, "%1.json"_q % file_base_name));
 }
 
 TXTRecordingInformationWriter::TXTRecordingInformationWriter(const QString &file_base_name) : file_base_name{file_base_name} {
@@ -166,7 +166,7 @@ void CompositeRecordingInformationWriter::write(const QVariantMap &information) 
 
 
 
-RecordingInformation::Writer::ptr RecordingInformation::json(const QString& file_base_name, const Configuration::ptr &configuration)
+RecordingInformation::Writer::ptr RecordingInformation::json(const QString& file_base_name, Configuration &configuration)
 {
   return make_shared<JSONRecordingInformationWriter>(file_base_name, configuration);
 }

--- a/src/image_handlers/backend/recordinginformation.h
+++ b/src/image_handlers/backend/recordinginformation.h
@@ -34,11 +34,11 @@ public:
     typedef std::shared_ptr<Writer> ptr;
     virtual void write(const QVariantMap &information) = 0;
   };
-  RecordingInformation(const Configuration::ptr &configuration, Imager *imager);
+  RecordingInformation(const Configuration &configuration, Imager *imager);
   ~RecordingInformation();
   void set_writer(const Writer::ptr &writer);
   void set_ended(int total_frames, int width, int height, uint8_t bpp, uint8_t channels);
-  static Writer::ptr json(const QString &file_base_name, const Configuration::ptr &configuration);
+  static Writer::ptr json(const QString &file_base_name, Configuration &configuration);
   static Writer::ptr txt(const QString &file_base_name);
   static Writer::ptr composite(const QList<Writer::ptr> &writers);
 private:

--- a/src/image_handlers/frontend/displayimage.cpp
+++ b/src/image_handlers/frontend/displayimage.cpp
@@ -40,7 +40,7 @@ using namespace std;
 using namespace std::placeholders;
 
 DPTR_IMPL(DisplayImage) {
-  Configuration::ptr configuration;
+  const Configuration &configuration;
   DisplayImage *q;
   unique_ptr<fps_counter> capture_fps;
   atomic_bool recording;
@@ -64,7 +64,7 @@ DPTR_IMPL(DisplayImage) {
   
   atomic_bool debayer;
   
-//         d->sobel(*cv_image, d->configuration->sobel_blur_size(), d->configuration->sobel_kernel(), d->configuration->sobel_scale(), d->configuration->sobel_delta());
+//         d->sobel(*cv_image, d->configuration.sobel_blur_size(), d->configuration.sobel_kernel(), d->configuration.sobel_scale(), d->configuration.sobel_delta());
 
   QElapsedTimer elapsed;
   QRect imageRect;
@@ -96,7 +96,7 @@ DisplayImage::~DisplayImage()
 
 }
 
-DisplayImage::DisplayImage(const Configuration::ptr & configuration, QObject* parent)
+DisplayImage::DisplayImage(const Configuration &configuration, QObject* parent)
   : QObject(parent), dptr(configuration, this)
 {
   d->capture_fps.reset(new fps_counter([=](double fps){ emit displayFPS(fps);}, fps_counter::Elapsed) );
@@ -126,21 +126,21 @@ bool DisplayImage::Private::should_display_frame() const
 
 void DisplayImage::read_settings()
 {
-  d->limit_fps = d->recording ? d->configuration->limit_fps_recording() : d->configuration->limit_fps();
-  d->min_milliseconds_elapsed = 1000/(d->recording ? d->configuration->max_display_fps_recording() : d->configuration->max_display_fps() );
+  d->limit_fps = d->recording ? d->configuration.limit_fps_recording() : d->configuration.limit_fps();
+  d->min_milliseconds_elapsed = 1000/(d->recording ? d->configuration.max_display_fps_recording() : d->configuration.max_display_fps() );
   
-  d->edge_detection_sobel =  d->configuration->edge_algorithm() == Configuration::Sobel;
-  d->sobel_kernel = d->configuration->sobel_kernel();
-  d->sobel_blur_size = d->configuration->sobel_blur_size();
-  d->sobel_delta = d->configuration->sobel_delta();
-  d->sobel_scale = d->configuration->sobel_scale();
+  d->edge_detection_sobel =  d->configuration.edge_algorithm() == Configuration::Sobel;
+  d->sobel_kernel = d->configuration.sobel_kernel();
+  d->sobel_blur_size = d->configuration.sobel_blur_size();
+  d->sobel_delta = d->configuration.sobel_delta();
+  d->sobel_scale = d->configuration.sobel_scale();
 
-  d->edge_detection_canny =  d->configuration->edge_algorithm() == Configuration::Canny;
-  d->canny_blur = d->configuration->canny_blur_size();
-  d->canny_kernel_size = d->configuration->canny_kernel_size();
-  d->canny_low_threshold = d->configuration->canny_low_threshold();
-  d->canny_threshold_ratio = d->configuration->canny_threshold_ratio();
-  d->debayer = d->configuration->debayer();
+  d->edge_detection_canny =  d->configuration.edge_algorithm() == Configuration::Canny;
+  d->canny_blur = d->configuration.canny_blur_size();
+  d->canny_kernel_size = d->configuration.canny_kernel_size();
+  d->canny_low_threshold = d->configuration.canny_low_threshold();
+  d->canny_threshold_ratio = d->configuration.canny_threshold_ratio();
+  d->debayer = d->configuration.debayer();
 }
 
 

--- a/src/image_handlers/frontend/displayimage.h
+++ b/src/image_handlers/frontend/displayimage.h
@@ -29,7 +29,7 @@ class DisplayImage : public QObject, public ImageHandler
 Q_OBJECT
 public:
     ~DisplayImage();
-    DisplayImage(const Configuration::ptr &configuration, QObject* parent = 0);
+    DisplayImage(const Configuration &configuration, QObject* parent = 0);
     virtual void handle(const Frame::ptr &frame);
     void setRecording(bool recording);
     QRect imageRect() const;

--- a/src/image_handlers/frontend/histogram.cpp
+++ b/src/image_handlers/frontend/histogram.cpp
@@ -35,7 +35,7 @@
 using namespace std;
 
 DPTR_IMPL(Histogram) {
-  Configuration::ptr configuration;
+  const Configuration &configuration;
   Histogram *q;
   atomic_bool recording;
   atomic_bool histogram_disable_on_recording;
@@ -73,7 +73,7 @@ Histogram::~Histogram()
 {
 }
 
-Histogram::Histogram(const Configuration::ptr &configuration, QObject* parent) : QObject(parent), dptr(configuration, this)
+Histogram::Histogram(const Configuration &configuration, QObject* parent) : QObject(parent), dptr(configuration, this)
 {
   d->last.start();
   d->recording = false;
@@ -216,9 +216,9 @@ void Histogram::setRecording(bool recording)
 
 void Histogram::read_settings()
 {
-  d->histogram_disable_on_recording = d->configuration->histogram_disable_on_recording();
-  d->histogram_timeout = d->configuration->histogram_timeout();
-  d->histogram_timeout_recording = d->configuration->histogram_timeout_recording();
+  d->histogram_disable_on_recording = d->configuration.histogram_disable_on_recording();
+  d->histogram_timeout = d->configuration.histogram_timeout();
+  d->histogram_timeout_recording = d->configuration.histogram_timeout_recording();
 }
 
 

--- a/src/image_handlers/frontend/histogram.h
+++ b/src/image_handlers/frontend/histogram.h
@@ -36,7 +36,7 @@ public:
     All,
   };
   ~Histogram();
-  Histogram(const Configuration::ptr &configuration, QObject* parent = 0);
+  Histogram(const Configuration &configuration, QObject* parent = 0);
   virtual void handle(const Frame::ptr &frame);
   void set_bins(std::size_t bins_size);
   void setRecording(bool recording);

--- a/src/image_handlers/output_writers/cvvideowriter.cpp
+++ b/src/image_handlers/output_writers/cvvideowriter.cpp
@@ -26,12 +26,12 @@ using namespace std;
 
 DPTR_IMPL(cvVideoWriter) {
   QString filename;
-  Configuration::ptr configuration;
+  const Configuration &configuration;
   cvVideoWriter *q;
   cv::VideoWriter videoWriter;
 };
 
-cvVideoWriter::cvVideoWriter(const Configuration::ptr & configuration ) : dptr(configuration->savefile(), configuration, this)
+cvVideoWriter::cvVideoWriter(const Configuration &configuration ) : dptr(configuration.savefile(), configuration, this)
 {
   qDebug() << "writing to " << filename();
 }
@@ -52,7 +52,7 @@ void cvVideoWriter::handle ( const Frame::ptr &frame )
   auto size = cv::Size{frame->mat().cols, frame->mat().rows};
   try {
     if(!d->videoWriter.isOpened())
-      d->videoWriter.open(d->filename.toStdString(), fourcc(d->configuration->video_codec().toStdString()), 25, size);
+      d->videoWriter.open(d->filename.toStdString(), fourcc(d->configuration.video_codec().toStdString()), 25, size);
     if(! d->videoWriter.isOpened()) {
       throw SaveImages::Error::openingFile(d->filename, QObject::tr("Check that output directory exists, and that the selected video encoder is supported by your system."));
     }

--- a/src/image_handlers/output_writers/cvvideowriter.h
+++ b/src/image_handlers/output_writers/cvvideowriter.h
@@ -25,7 +25,7 @@
 class cvVideoWriter : public FileWriter
 {
 public:
- cvVideoWriter(const Configuration::ptr &configuration);
+ cvVideoWriter(const Configuration &configuration);
  ~cvVideoWriter();
  QString filename() const override;
  void handle(const Frame::ptr &frame) override;

--- a/src/image_handlers/output_writers/filewriter.cpp
+++ b/src/image_handlers/output_writers/filewriter.cpp
@@ -25,9 +25,9 @@ using namespace std;
 QMap< Configuration::SaveFormat, FileWriter::Factory > FileWriter::factories()
 {
   return {
-    {Configuration::SER, [](const QString &deviceName, const Configuration::ptr &configuration){ return make_shared<SERWriter>(deviceName, configuration); }},
-    {Configuration::Video, [](const QString &, const Configuration::ptr &configuration){ return make_shared<cvVideoWriter>(configuration); }},
-    {Configuration::PNG, [](const QString &, const Configuration::ptr &configuration){ return make_shared<ImageFileWriter>(ImageFileWriter::PNG, configuration); }},
-    {Configuration::FITS, [](const QString &, const Configuration::ptr &configuration){ return make_shared<ImageFileWriter>(ImageFileWriter::FITS, configuration); }},
+    {Configuration::SER, [](const QString &deviceName, const Configuration *configuration){ return make_shared<SERWriter>(deviceName, *configuration); }},
+    {Configuration::Video, [](const QString &, const Configuration *configuration){ return make_shared<cvVideoWriter>(*configuration); }},
+    {Configuration::PNG, [](const QString &, const Configuration *configuration){ return make_shared<ImageFileWriter>(ImageFileWriter::PNG, *configuration); }},
+    {Configuration::FITS, [](const QString &, const Configuration *configuration){ return make_shared<ImageFileWriter>(ImageFileWriter::FITS, *configuration); }},
   };
 }

--- a/src/image_handlers/output_writers/filewriter.h
+++ b/src/image_handlers/output_writers/filewriter.h
@@ -27,7 +27,7 @@
 class FileWriter : public ImageHandler {
 public:
   typedef std::shared_ptr<FileWriter> Ptr;
-  typedef std::function<Ptr(const QString &deviceName, const Configuration::ptr &configuration)> Factory;
+  typedef std::function<Ptr(const QString &deviceName, const Configuration *configuration)> Factory;
   virtual void handle(const Frame::ptr &frame) = 0;
   virtual QString filename() const = 0;
   static QMap<Configuration::SaveFormat, Factory> factories();

--- a/src/image_handlers/output_writers/imagefilewriter.cpp
+++ b/src/image_handlers/output_writers/imagefilewriter.cpp
@@ -28,7 +28,7 @@ using namespace std;
 using namespace std::placeholders;
 
 DPTR_IMPL(ImageFileWriter) {
-  Configuration::ptr configuration;
+  const Configuration &configuration;
   QString filename;
   ImageFileWriter *q;
   function<void(const Frame::ptr&)> writer;
@@ -38,7 +38,7 @@ DPTR_IMPL(ImageFileWriter) {
   void saveCV(const Frame::ptr &frame, const QString &extension) const;
 };
 
-ImageFileWriter::ImageFileWriter(ImageFileWriter::Format format, const Configuration::ptr & configuration) : dptr(configuration, configuration->savefile(), this)
+ImageFileWriter::ImageFileWriter(ImageFileWriter::Format format, const Configuration &configuration) : dptr(configuration, configuration.savefile(), this)
 {
   qDebug() << "Format: " << format;
   switch(format) {

--- a/src/image_handlers/output_writers/imagefilewriter.h
+++ b/src/image_handlers/output_writers/imagefilewriter.h
@@ -25,7 +25,7 @@ class ImageFileWriter : public FileWriter
 {
 public:
   enum Format {PNG, FITS};
-  ImageFileWriter(Format format, const Configuration::ptr &configuration);
+  ImageFileWriter(Format format, const Configuration &configuration);
   QString filename() const override;
   void handle(const Frame::ptr & frame) override;
   ~ImageFileWriter();

--- a/src/image_handlers/output_writers/serwriter.cpp
+++ b/src/image_handlers/output_writers/serwriter.cpp
@@ -35,12 +35,12 @@ DPTR_IMPL(SERWriter) {
   vector<QDateTime> frames_datetimes;
 };
 
-SERWriter::SERWriter ( const QString& deviceName, const Configuration::ptr & configuration ) : dptr(this)
+SERWriter::SERWriter ( const QString& deviceName, const Configuration &configuration ) : dptr(this)
 {
-  d->file.setFileName(configuration->savefile());
-  qDebug() << "Using buffered output: " << configuration->buffered_output();
+  d->file.setFileName(configuration.savefile());
+  qDebug() << "Using buffered output: " << configuration.buffered_output();
   bool couldOpen = false;
-  if(configuration->buffered_output()) {
+  if(configuration.buffered_output()) {
     couldOpen = d->file.open(QIODevice::ReadWrite);
   }
   else {
@@ -53,8 +53,8 @@ SERWriter::SERWriter ( const QString& deviceName, const Configuration::ptr & con
   empty_header.datetime_utc = SER_Header::timestamp(QDateTime::currentDateTimeUtc());
   qDebug() << "Starting datetime: " << QDateTime::currentDateTimeUtc() << ", : " << SER_Header::qdatetime(empty_header.datetime_utc);
   ::strcpy(empty_header.camera, deviceName.left(40).toLatin1());
-  ::strcpy(empty_header.observer, configuration->observer().left(40).toLatin1());
-  ::strcpy(empty_header.telescope, configuration->telescope().left(40).toLatin1());
+  ::strcpy(empty_header.observer, configuration.observer().left(40).toLatin1());
+  ::strcpy(empty_header.telescope, configuration.telescope().left(40).toLatin1());
   d->file.write(reinterpret_cast<char*>(&empty_header), sizeof(empty_header));
   d->file.flush();
   d->header = reinterpret_cast<SER_Header*>(d->file.map(0, sizeof(SER_Header)));

--- a/src/image_handlers/output_writers/serwriter.h
+++ b/src/image_handlers/output_writers/serwriter.h
@@ -25,7 +25,7 @@
 class SERWriter : public FileWriter
 {
 public:
- SERWriter(const QString &deviceName, const Configuration::ptr &configuration);
+ SERWriter(const QString &deviceName, const Configuration &configuration);
  ~SERWriter();
  QString filename() const override;
  void handle(const Frame::ptr &frame) override;

--- a/src/network/client/gui/connectionmanager.cpp
+++ b/src/network/client/gui/connectionmanager.cpp
@@ -47,7 +47,7 @@ DPTR_IMPL(ConnectionManager) {
   NetworkDispatcher::ptr dispatcher;
   RemoteDriver::ptr remoteDriver;
   NetworkClient::ptr client;
-  RemoteConfiguration::ptr configuration;
+  unique_ptr<RemoteConfiguration> configuration;
   
   PlanetaryImagerMainWindow *mainWindow = nullptr;
   
@@ -68,7 +68,7 @@ ConnectionManager::ConnectionManager() : dptr(this)
   d->dispatcher = make_shared<NetworkDispatcher>();
   d->client = make_shared<NetworkClient>(d->dispatcher);
   d->remoteDriver = make_shared<RemoteDriver>(d->dispatcher);
-  d->configuration = make_shared<RemoteConfiguration>(d->dispatcher);
+  d->configuration = make_unique<RemoteConfiguration>(d->dispatcher);
   auto connectButton = d->ui->buttonBox->addButton(tr("Connect"), QDialogButtonBox::ApplyRole);
   connect(connectButton, &QPushButton::clicked, this, [=] {
     d->configuration->set_server_host(d->ui->host->text());
@@ -125,7 +125,7 @@ void ConnectionManager::Private::onConnected()
 {
   ui->status->clear();
   auto imageHandlers = make_shared<ImageHandlers>();
-  auto planetaryImager = make_shared<PlanetaryImager>(remoteDriver, imageHandlers, make_shared<RemoteSaveImages>(dispatcher), configuration);
+  auto planetaryImager = make_shared<PlanetaryImager>(remoteDriver, imageHandlers, make_shared<RemoteSaveImages>(dispatcher), *configuration);
   mainWindow = new PlanetaryImagerMainWindow{planetaryImager, imageHandlers, make_shared<RemoteFilesystemBrowser>(dispatcher)};
   mainWindow->show();
   q->hide();

--- a/src/network/server/configurationforwarder.cpp
+++ b/src/network/server/configurationforwarder.cpp
@@ -24,7 +24,7 @@ using namespace std;
 using namespace std::placeholders;
 
 DPTR_IMPL(ConfigurationForwarder) {
-  Configuration::ptr configuration;
+  Configuration &configuration;
   ConfigurationForwarder *q;
   void get(const NetworkPacket::ptr &packet);
   void set(const NetworkPacket::ptr &packet);
@@ -39,17 +39,17 @@ DPTR_IMPL(ConfigurationForwarder) {
 };
 
 #define register_conf_function(name, type) d->names[#name] = Private::ConfigurationFunctions{ \
-  [this] { return QVariant{ d->configuration->name() }; }, \
-  [this](const QVariant &v) { d->configuration->set_ ##name( v.value<type>() ); }, \
-  [this] { d->configuration->reset_ ##name(); }, \
+  [this] { return QVariant{ d->configuration.name() }; }, \
+  [this](const QVariant &v) { d->configuration.set_ ##name( v.value<type>() ); }, \
+  [this] { d->configuration.reset_ ##name(); }, \
 };
 #define register_conf_function_enum(name, type) d->names[#name] = Private::ConfigurationFunctions{ \
-  [this] { return QVariant{ static_cast<int>(d->configuration->name() ) }; }, \
-  [this](const QVariant &v) { d->configuration->set_ ##name( static_cast<type>(v.value<int>() ) ); }, \
-  [this] { d->configuration->reset_ ##name(); }, \
+  [this] { return QVariant{ static_cast<int>(d->configuration.name() ) }; }, \
+  [this](const QVariant &v) { d->configuration.set_ ##name( static_cast<type>(v.value<int>() ) ); }, \
+  [this] { d->configuration.reset_ ##name(); }, \
 };
 
-ConfigurationForwarder::ConfigurationForwarder(const Configuration::ptr& configuration, const NetworkDispatcher::ptr& dispatcher) : NetworkReceiver{dispatcher}, dptr(configuration, this)
+ConfigurationForwarder::ConfigurationForwarder(Configuration &configuration, const NetworkDispatcher::ptr& dispatcher) : NetworkReceiver{dispatcher}, dptr(configuration, this)
 {
   register_handler(ConfigurationProtocol::Get, bind(&Private::get, d.get(), _1));
   register_handler(ConfigurationProtocol::Set, bind(&Private::set, d.get(), _1));

--- a/src/network/server/configurationforwarder.h
+++ b/src/network/server/configurationforwarder.h
@@ -27,7 +27,7 @@
 class ConfigurationForwarder : public NetworkReceiver
 {
 public:
-  ConfigurationForwarder(const Configuration::ptr &configuration, const NetworkDispatcher::ptr &dispatcher);
+  ConfigurationForwarder(Configuration &configuration, const NetworkDispatcher::ptr &dispatcher);
   ~ConfigurationForwarder();
 private:
   DPTR

--- a/src/planetaryimager.cpp
+++ b/src/planetaryimager.cpp
@@ -27,7 +27,7 @@ DPTR_IMPL(PlanetaryImager) {
   Driver::ptr driver;
   ImageHandler::ptr imageHandler;
   SaveImages::ptr saveImages;
-  Configuration::ptr configuration;
+  Configuration &configuration;
   PlanetaryImager *q;
   
   Driver::Cameras cameras;
@@ -40,7 +40,7 @@ PlanetaryImager::PlanetaryImager(
   const Driver::ptr &driver,
   const ImageHandler::ptr &imageHandler,
   const SaveImages::ptr &saveImages,
-  const Configuration::ptr &configuration
+  Configuration &configuration
 ) : QObject{}, dptr(driver, imageHandler, saveImages, configuration, this)
 {
   d->initDevicesWatcher();
@@ -60,7 +60,7 @@ SaveImages::ptr PlanetaryImager::saveImages() const
   return d->saveImages;
 }
 
-Configuration::ptr PlanetaryImager::configuration() const
+Configuration &PlanetaryImager::configuration() const
 {
   return d->configuration;
 }

--- a/src/planetaryimager.h
+++ b/src/planetaryimager.h
@@ -36,13 +36,13 @@ public:
         const Driver::ptr &driver,
         const ImageHandler::ptr &imageHandler,
         const SaveImages::ptr &saveImages,
-        const Configuration::ptr &configuration
+        Configuration &configuration
     );
     ~PlanetaryImager();
   Driver::Cameras cameras() const;
   Imager *imager() const;
   SaveImages::ptr saveImages() const;
-  Configuration::ptr configuration() const;
+  Configuration &configuration() const;
   
 public slots:
   void scanCameras();

--- a/src/planetaryimager_daemon.cpp
+++ b/src/planetaryimager_daemon.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
     
     LogHandler log_handler{commandLine};
     
-    auto configuration = make_shared<Configuration>();
+    Configuration configuration;
     auto driver = make_shared<SupportedDrivers>(commandLine.driversDirectories());
     auto dispatcher = make_shared<NetworkDispatcher>();
     auto save_images = make_shared<LocalSaveImages>(configuration);

--- a/src/planetaryimager_main.cpp
+++ b/src/planetaryimager_main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
     commandLine.backend().daemon("127.0.0.1").process();
     LogHandler log_handler{commandLine};
     
-    auto configuration = make_shared<Configuration>();
+    Configuration configuration;
     auto save_images = make_shared<LocalSaveImages>(configuration);
     auto drivers = make_shared<SupportedDrivers>(commandLine.driversDirectories());
     

--- a/src/planetaryimager_mainwindow.cpp
+++ b/src/planetaryimager_mainwindow.cpp
@@ -118,8 +118,8 @@ PlanetaryImagerMainWindow::~PlanetaryImagerMainWindow()
 
 void PlanetaryImagerMainWindow::Private::saveState()
 {
-  planetaryImager->configuration()->set_dock_status(q->saveState());
-  planetaryImager->configuration()->set_main_window_geometry(q->saveGeometry());
+  planetaryImager->configuration().set_dock_status(q->saveState());
+  planetaryImager->configuration().set_main_window_geometry(q->saveGeometry());
 }
 
 
@@ -155,7 +155,7 @@ PlanetaryImagerMainWindow::PlanetaryImagerMainWindow(
     d->ui->image->layout()->setSpacing(0);
     d->ui->image->layout()->addWidget(d->image_widget = new ZoomableImage(false));
 #ifdef HAVE_QT5_OPENGL // TODO: make configuration item
-    if(d->planetaryImager->configuration()->opengl())
+    if(d->planetaryImager->configuration().opengl())
       d->image_widget->setOpenGL();
 #endif
     d->image_widget->scene()->setBackgroundBrush(QBrush{Qt::black, Qt::Dense4Pattern});
@@ -184,8 +184,8 @@ PlanetaryImagerMainWindow::PlanetaryImagerMainWindow(
     d->image_widget->toolbar()->setFloatable(true);
     d->image_widget->toolbar()->setMovable(true);
     
-    restoreGeometry(d->planetaryImager->configuration()->main_window_geometry());
-    restoreState(d->planetaryImager->configuration()->dock_status());
+    restoreGeometry(d->planetaryImager->configuration().main_window_geometry());
+    restoreState(d->planetaryImager->configuration().dock_status());
     connect(d->ui->actionAbout, &QAction::triggered, bind(&QMessageBox::about, this, tr("About"),
 							  tr("%1 version %2.\nFast imaging capture software for planetary imaging").arg(qApp->applicationDisplayName())
 							 .arg(qApp->applicationVersion())));
@@ -224,11 +224,11 @@ PlanetaryImagerMainWindow::PlanetaryImagerMainWindow(
     setupDockWidget(d->ui->actionCamera_Settings, d->ui->camera_settings);
     setupDockWidget(d->ui->actionRecording, d->ui->recording);
     setupDockWidget(d->ui->actionHistogram, d->ui->histogram);
-    if(! d->planetaryImager->configuration()->widgets_setup_first_run() ) {
+    if(! d->planetaryImager->configuration().widgets_setup_first_run() ) {
       tabifyDockWidget(d->ui->chipInfoWidget, d->ui->camera_settings);
       tabifyDockWidget(d->ui->chipInfoWidget, d->ui->histogram);
       tabifyDockWidget(d->ui->chipInfoWidget, d->ui->recording);
-      d->planetaryImager->configuration()->set_widgets_setup_first_run(true);
+      d->planetaryImager->configuration().set_widgets_setup_first_run(true);
     }
     qDebug() << "file " << logFilePath << "exists: " << QFile::exists(logFilePath);
     d->ui->actionOpen_log_file_folder->setMenuRole(QAction::ApplicationSpecificRole);

--- a/src/widgets/cameracontrolswidget.h
+++ b/src/widgets/cameracontrolswidget.h
@@ -28,7 +28,7 @@ class CameraControlsWidget : public QWidget
 {
 public:
 ~CameraControlsWidget();
-CameraControlsWidget(Imager *imager, const Configuration::ptr &configuration, const FilesystemBrowser::ptr &filesystemBrowser, QWidget* parent = 0);
+CameraControlsWidget(Imager *imager, Configuration &configuration, const FilesystemBrowser::ptr &filesystemBrowser, QWidget* parent = 0);
 
 private:
     DPTR

--- a/src/widgets/configurationdialog.cpp
+++ b/src/widgets/configurationdialog.cpp
@@ -30,7 +30,7 @@ using namespace std::placeholders;
 using namespace std;
 
 DPTR_IMPL(ConfigurationDialog) {
-  Configuration::ptr configuration;
+  Configuration &configuration;
   ConfigurationDialog *q;
   unique_ptr<Ui::ConfigurationDialog> ui;
 };
@@ -39,124 +39,124 @@ ConfigurationDialog::~ConfigurationDialog()
 {
 }
 
-ConfigurationDialog::ConfigurationDialog(const Configuration::ptr & configuration, QWidget* parent) : QDialog(parent), dptr(configuration, this)
+ConfigurationDialog::ConfigurationDialog(Configuration &configuration, QWidget* parent) : QDialog(parent), dptr(configuration, this)
 {
-    static bool original_opengl_setting = configuration->opengl();
+    static bool original_opengl_setting = d->configuration.opengl();
     d->ui.reset(new Ui::ConfigurationDialog);
     d->ui->setupUi(this);
 #ifndef HAVE_QT5_OPENGL
     d->ui->opengl->hide();
 #endif
-    connect(d->ui->debayer, &QCheckBox::toggled, bind(&Configuration::set_debayer, configuration.get(), _1));
-    connect(d->ui->opengl, &QCheckBox::toggled, bind(&Configuration::set_opengl, configuration.get(), _1));
-    d->ui->debayer->setChecked(configuration->debayer());
-    d->ui->opengl->setChecked(configuration->opengl());
-    d->ui->pauseShouldStopRecordingTimeout->setChecked(configuration->recording_pause_stops_timer());
-    connect(d->ui->pauseShouldStopRecordingTimeout, &QCheckBox::toggled, bind(&Configuration::set_recording_pause_stops_timer, configuration.get(), _1));
+    connect(d->ui->debayer, &QCheckBox::toggled, bind(&Configuration::set_debayer, &d->configuration, _1));
+    connect(d->ui->opengl, &QCheckBox::toggled, bind(&Configuration::set_opengl, &d->configuration, _1));
+    d->ui->debayer->setChecked(d->configuration.debayer());
+    d->ui->opengl->setChecked(d->configuration.opengl());
+    d->ui->pauseShouldStopRecordingTimeout->setChecked(d->configuration.recording_pause_stops_timer());
+    connect(d->ui->pauseShouldStopRecordingTimeout, &QCheckBox::toggled, bind(&Configuration::set_recording_pause_stops_timer, &d->configuration, _1));
     
     auto edge_settings = [=] {
-      d->ui->cannySettingsBox->setVisible(d->configuration->edge_algorithm() == Configuration::Canny);
-      d->ui->sobelSettingsBox->setVisible(d->configuration->edge_algorithm() == Configuration::Sobel);
+      d->ui->cannySettingsBox->setVisible(d->configuration.edge_algorithm() == Configuration::Canny);
+      d->ui->sobelSettingsBox->setVisible(d->configuration.edge_algorithm() == Configuration::Sobel);
     };
     edge_settings();
     QButtonGroup *edgeAlgorithm = new QButtonGroup(this);
     edgeAlgorithm->addButton(d->ui->edge_canny);
     edgeAlgorithm->addButton(d->ui->edge_sobel);
     
-    d->ui->edge_canny->setChecked(configuration->edge_algorithm() == Configuration::Canny);
-    d->ui->edge_sobel->setChecked(configuration->edge_algorithm() == Configuration::Sobel);
+    d->ui->edge_canny->setChecked(d->configuration.edge_algorithm() == Configuration::Canny);
+    d->ui->edge_sobel->setChecked(d->configuration.edge_algorithm() == Configuration::Sobel);
     
     QMap<QAbstractButton*, Configuration::EdgeAlgorithm> edgeAlgorithmWidgets {
         {d->ui->edge_canny, Configuration::Canny},
         {d->ui->edge_sobel, Configuration::Sobel},
     };
     connect(edgeAlgorithm, F_PTR(QButtonGroup, buttonToggled, QAbstractButton*, bool), [=]{
-      d->configuration->set_edge_algorithm(edgeAlgorithmWidgets[edgeAlgorithm->checkedButton()]);
+      d->configuration.set_edge_algorithm(edgeAlgorithmWidgets[edgeAlgorithm->checkedButton()]);
       edge_settings();
     });
     
     auto reload_advanced_edge_settings = [=] {
-        d->ui->sobelKernel->setCurrentText(QString::number(d->configuration->sobel_kernel()));
-        d->ui->sobelScale->setValue(d->configuration->sobel_scale());
-        d->ui->sobelDelta->setValue(d->configuration->sobel_delta());
-        d->ui->sobelBlurSize->setValue(d->configuration->sobel_blur_size());
+        d->ui->sobelKernel->setCurrentText(QString::number(d->configuration.sobel_kernel()));
+        d->ui->sobelScale->setValue(d->configuration.sobel_scale());
+        d->ui->sobelDelta->setValue(d->configuration.sobel_delta());
+        d->ui->sobelBlurSize->setValue(d->configuration.sobel_blur_size());
         
-        d->ui->cannyKernelSize->setValue(d->configuration->canny_kernel_size());
-        d->ui->cannyBlurSize->setValue(d->configuration->canny_blur_size());
-        d->ui->cannyThreshold->setValue(d->configuration->canny_low_threshold());
-        d->ui->cannyRatio->setValue(d->configuration->canny_threshold_ratio());
+        d->ui->cannyKernelSize->setValue(d->configuration.canny_kernel_size());
+        d->ui->cannyBlurSize->setValue(d->configuration.canny_blur_size());
+        d->ui->cannyThreshold->setValue(d->configuration.canny_low_threshold());
+        d->ui->cannyRatio->setValue(d->configuration.canny_threshold_ratio());
     };
     reload_advanced_edge_settings();
-    connect(d->ui->sobelKernel, &QComboBox::currentTextChanged, [=](const QString &text) { d->configuration->set_sobel_kernel(static_cast<Configuration::EdgeAlgorithm>(text.toInt())); });
-    connect(d->ui->sobelBlurSize, F_PTR(QSpinBox, valueChanged, int), [=](int size) { d->configuration->set_sobel_blur_size(size); });
-    connect(d->ui->sobelScale, F_PTR(QDoubleSpinBox, valueChanged, double), [=](double scale) { d->configuration->set_sobel_scale(scale); });
-    connect(d->ui->sobelDelta, F_PTR(QDoubleSpinBox, valueChanged, double), [=](double delta) { d->configuration->set_sobel_delta(delta); });
+    connect(d->ui->sobelKernel, &QComboBox::currentTextChanged, [=](const QString &text) { d->configuration.set_sobel_kernel(static_cast<Configuration::EdgeAlgorithm>(text.toInt())); });
+    connect(d->ui->sobelBlurSize, F_PTR(QSpinBox, valueChanged, int), [=](int size) { d->configuration.set_sobel_blur_size(size); });
+    connect(d->ui->sobelScale, F_PTR(QDoubleSpinBox, valueChanged, double), [=](double scale) { d->configuration.set_sobel_scale(scale); });
+    connect(d->ui->sobelDelta, F_PTR(QDoubleSpinBox, valueChanged, double), [=](double delta) { d->configuration.set_sobel_delta(delta); });
     
-    connect(d->ui->cannyKernelSize, F_PTR(QSpinBox, valueChanged, int), [=](double size) { d->configuration->set_canny_kernel_size(size); });
-    connect(d->ui->cannyBlurSize, F_PTR(QSpinBox, valueChanged, int), [=](double size) { d->configuration->set_canny_blur_size(size); });
+    connect(d->ui->cannyKernelSize, F_PTR(QSpinBox, valueChanged, int), [=](double size) { d->configuration.set_canny_kernel_size(size); });
+    connect(d->ui->cannyBlurSize, F_PTR(QSpinBox, valueChanged, int), [=](double size) { d->configuration.set_canny_blur_size(size); });
     
-    connect(d->ui->cannyThreshold, F_PTR(QDoubleSpinBox, valueChanged, double), bind(&Configuration::set_canny_low_threshold, d->configuration.get(), _1));
-    connect(d->ui->cannyRatio, F_PTR(QDoubleSpinBox, valueChanged, double), bind(&Configuration::set_canny_threshold_ratio, d->configuration.get(), _1));
+    connect(d->ui->cannyThreshold, F_PTR(QDoubleSpinBox, valueChanged, double), bind(&Configuration::set_canny_low_threshold, &d->configuration, _1));
+    connect(d->ui->cannyRatio, F_PTR(QDoubleSpinBox, valueChanged, double), bind(&Configuration::set_canny_threshold_ratio, &d->configuration, _1));
     
     connect(d->ui->cannyResetDefaults, &QPushButton::clicked, [=]{
-        d->configuration->resetCannyAdvancedSettings();
+        d->configuration.resetCannyAdvancedSettings();
         reload_advanced_edge_settings();
     });
     connect(d->ui->sobelResetDefaults, &QPushButton::clicked, [=]{
-        d->configuration->resetSobelAdvancedSettings();
+        d->configuration.resetSobelAdvancedSettings();
         reload_advanced_edge_settings();
     });
     
-    d->ui->buffered_file->setChecked(configuration->buffered_output());
+    d->ui->buffered_file->setChecked(d->configuration.buffered_output());
     
     // FPS Limit - not recording
-    d->ui->enable_fps_limit->setChecked(configuration->limit_fps());
-    d->ui->fps_limit->setValue(configuration->max_display_fps());
-    d->ui->fps_limit->setEnabled(configuration->limit_fps());
-    connect(d->ui->enable_fps_limit, &QCheckBox::toggled, [this, &configuration] (bool checked){
-      configuration->set_limit_fps(checked);
+    d->ui->enable_fps_limit->setChecked(d->configuration.limit_fps());
+    d->ui->fps_limit->setValue(d->configuration.max_display_fps());
+    d->ui->fps_limit->setEnabled(d->configuration.limit_fps());
+    connect(d->ui->enable_fps_limit, &QCheckBox::toggled, [this] (bool checked){
+      d->configuration.set_limit_fps(checked);
       d->ui->fps_limit->setEnabled(checked);
     });
-    connect(d->ui->fps_limit, F_PTR(QSpinBox, valueChanged, int), [ &configuration] (int v){ configuration->set_max_display_fps(v); });
+    connect(d->ui->fps_limit, F_PTR(QSpinBox, valueChanged, int), [this] (int v){ d->configuration.set_max_display_fps(v); });
     
     // FPS Limit - recording
-    d->ui->enable_fps_limit_recording->setChecked(configuration->limit_fps_recording());
-    d->ui->fps_limit_recording->setValue(configuration->max_display_fps_recording());
-    d->ui->fps_limit_recording->setEnabled(configuration->limit_fps_recording());
-    connect(d->ui->enable_fps_limit_recording, &QCheckBox::toggled, [this, &configuration] (bool checked){
-      configuration->set_limit_fps_recording(checked);
+    d->ui->enable_fps_limit_recording->setChecked(d->configuration.limit_fps_recording());
+    d->ui->fps_limit_recording->setValue(d->configuration.max_display_fps_recording());
+    d->ui->fps_limit_recording->setEnabled(d->configuration.limit_fps_recording());
+    connect(d->ui->enable_fps_limit_recording, &QCheckBox::toggled, [this] (bool checked){
+      d->configuration.set_limit_fps_recording(checked);
       d->ui->fps_limit_recording->setEnabled(checked);
     });
-    connect(d->ui->fps_limit_recording, F_PTR(QSpinBox, valueChanged, int), [ &configuration] (int v){ configuration->set_max_display_fps_recording(v); });
+    connect(d->ui->fps_limit_recording, F_PTR(QSpinBox, valueChanged, int), [this] (int v){ d->configuration.set_max_display_fps_recording(v); });
 
-    d->ui->histogram_timeout->setValue(configuration->histogram_timeout() / 1000.);
-    connect(d->ui->histogram_timeout, F_PTR(QDoubleSpinBox, valueChanged, double), [&configuration](double v) { configuration->set_histogram_timeout(v*1000); });
-    d->ui->histogram_disable_on_recording->setChecked(configuration->histogram_disable_on_recording());
-    connect(d->ui->histogram_disable_on_recording, &QCheckBox::toggled, [this, &configuration](bool c) {
+    d->ui->histogram_timeout->setValue(d->configuration.histogram_timeout() / 1000.);
+    connect(d->ui->histogram_timeout, F_PTR(QDoubleSpinBox, valueChanged, double), [this](double v) { d->configuration.set_histogram_timeout(v*1000); });
+    d->ui->histogram_disable_on_recording->setChecked(d->configuration.histogram_disable_on_recording());
+    connect(d->ui->histogram_disable_on_recording, &QCheckBox::toggled, [this](bool c) {
       d->ui->histogram_timeout_recording->setEnabled(!c);
-      configuration->set_histogram_disable_on_recording(c);
+      d->configuration.set_histogram_disable_on_recording(c);
     });
-    d->ui->histogram_timeout_recording->setEnabled(! configuration->histogram_disable_on_recording());
-    d->ui->histogram_timeout_recording->setValue(configuration->histogram_timeout_recording() / 1000.);
-    connect(d->ui->histogram_timeout_recording, F_PTR(QDoubleSpinBox, valueChanged, double), [&configuration](double v) { configuration->set_histogram_timeout_recording(v*1000); });
+    d->ui->histogram_timeout_recording->setEnabled(! d->configuration.histogram_disable_on_recording());
+    d->ui->histogram_timeout_recording->setValue(d->configuration.histogram_timeout_recording() / 1000.);
+    connect(d->ui->histogram_timeout_recording, F_PTR(QDoubleSpinBox, valueChanged, double), [this](double v) { d->configuration.set_histogram_timeout_recording(v*1000); });
     
-    auto set_memory_limit = [=,&configuration](int value) {
+    auto set_memory_limit = [=](int value) {
       if(value < 1024)
-	d->ui->memory_limit_label->setText("%1 MB"_q % value);
+	      d->ui->memory_limit_label->setText("%1 MB"_q % value);
       else
-	d->ui->memory_limit_label->setText("%1 GB"_q.arg(static_cast<double>(value) / 1024., 0, 'f', 2) );
-      configuration->set_max_memory_usage(static_cast<long>(value) * 1024l * 1024l);
+	      d->ui->memory_limit_label->setText("%1 GB"_q.arg(static_cast<double>(value) / 1024., 0, 'f', 2) );
+      d->configuration.set_max_memory_usage(static_cast<long>(value) * 1024l * 1024l);
     };
     d->ui->memory_limit->setRange(0, 8*1024);
     connect(d->ui->memory_limit, &QSlider::valueChanged, set_memory_limit);
-    connect(d->ui->buffered_file, &QCheckBox::toggled, bind(&Configuration::set_buffered_output, configuration.get(), _1));
-    d->ui->memory_limit->setValue(configuration->max_memory_usage() / 1024 / 1024 );
+    connect(d->ui->buffered_file, &QCheckBox::toggled, bind(&Configuration::set_buffered_output, &d->configuration, _1));
+    d->ui->memory_limit->setValue(d->configuration.max_memory_usage() / 1024 / 1024 );
     set_memory_limit(d->ui->memory_limit->value());
         
-    d->ui->telescope->setText(configuration->telescope());
-    d->ui->observer->setText(configuration->observer());
-    connect(d->ui->observer, &QLineEdit::textChanged, bind(&Configuration::set_observer, configuration.get(), _1));
-    connect(d->ui->telescope, &QLineEdit::textChanged, bind(&Configuration::set_telescope, configuration.get(), _1));
+    d->ui->telescope->setText(d->configuration.telescope());
+    d->ui->observer->setText(d->configuration.observer());
+    connect(d->ui->observer, &QLineEdit::textChanged, bind(&Configuration::set_observer, &d->configuration, _1));
+    connect(d->ui->telescope, &QLineEdit::textChanged, bind(&Configuration::set_telescope, &d->configuration, _1));
     for(auto codec: QList<QPair<QString,QString>>{
         {"X264", tr("Good compression and quality")},
         {"MJPG", "Motion JPEG, good compression"},
@@ -170,10 +170,10 @@ ConfigurationDialog::ConfigurationDialog(const Configuration::ptr & configuratio
     }) {
         d->ui->video_codec->addItem("%1 (%2)"_q % codec.first % codec.second, codec.first);
     }
-    d->ui->video_codec->setCurrentIndex(d->ui->video_codec->findData(d->configuration->video_codec()));
-    connect(d->ui->video_codec, F_PTR(QComboBox, activated, int), [=](int index){ d->configuration->set_video_codec(d->ui->video_codec->itemData(index).toString()); });
-    connect(this, &QDialog::accepted, [&] {
-      if(original_opengl_setting != configuration->opengl()) {
+    d->ui->video_codec->setCurrentIndex(d->ui->video_codec->findData(d->configuration.video_codec()));
+    connect(d->ui->video_codec, F_PTR(QComboBox, activated, int), [=](int index){ d->configuration.set_video_codec(d->ui->video_codec->itemData(index).toString()); });
+    connect(this, &QDialog::accepted, [this] {
+      if(original_opengl_setting != d->configuration.opengl()) {
         QMessageBox::information(this, tr("Restart required"), tr("You changed the OpenGL setting. Please restart PlanetaryImage for this change to take effect"));
       }
     });

--- a/src/widgets/configurationdialog.h
+++ b/src/widgets/configurationdialog.h
@@ -28,7 +28,7 @@ class ConfigurationDialog : public QDialog
     Q_OBJECT
 public:
     ~ConfigurationDialog();
-    ConfigurationDialog(const Configuration::ptr &configuration, QWidget* parent = 0);
+    ConfigurationDialog(Configuration &configuration, QWidget* parent = 0);
 
 private:
   DPTR

--- a/src/widgets/histogramwidget.cpp
+++ b/src/widgets/histogramwidget.cpp
@@ -29,7 +29,7 @@ using namespace std::placeholders;
 
 DPTR_IMPL(HistogramWidget) {
   Histogram::ptr histogram;
-  Configuration::ptr configuration;
+  Configuration  &configuration;
   HistogramWidget *q;
   std::unique_ptr<Ui::HistogramWidget> ui;
   void got_histogram(const QImage& histogram, const QMap<Histogram::Channel, QVariantMap> &stats, Histogram::Channel channel);
@@ -41,7 +41,7 @@ HistogramWidget::~HistogramWidget()
 {
 }
 
-HistogramWidget::HistogramWidget(const Histogram::ptr &histogram, const Configuration::ptr &configuration, QWidget* parent) : QWidget(parent), dptr(histogram, configuration, this)
+HistogramWidget::HistogramWidget(const Histogram::ptr &histogram, Configuration &configuration, QWidget* parent) : QWidget(parent), dptr(histogram, configuration, this)
 {
     d->channel_combo_indexes = {
       {Histogram::Grayscale, 0},
@@ -52,26 +52,26 @@ HistogramWidget::HistogramWidget(const Histogram::ptr &histogram, const Configur
     };
     d->ui.reset(new Ui::HistogramWidget);
     d->ui->setupUi(this);
-    d->ui->histogram_bins->setValue(d->configuration->histogram_bins());
+    d->ui->histogram_bins->setValue(d->configuration.histogram_bins());
     
     auto update_bins = [&]{
       auto value = d->ui->histogram_bins->value();
       d->histogram->set_bins(value);
-      d->configuration->set_histogram_bins(value);
+      d->configuration.set_histogram_bins(value);
     };
     update_bins();
     connect(d->ui->histogram_bins, F_PTR(QSpinBox, valueChanged, int), update_bins);
     connect(d->histogram.get(), &Histogram::histogram, this, bind(&Private::got_histogram, d.get(), _1, _2, _3), Qt::QueuedConnection);
     connect(d->ui->histogram_logarithmic, &QCheckBox::toggled, this, bind(&Private::toggle_histogram_logarithmic, d.get(), _1));
     connect(d->ui->channel, F_PTR(QComboBox, currentIndexChanged, int), this, [this](int index) { d->histogram->setChannel(d->channel_combo_indexes.key(index)); });
-    d->toggle_histogram_logarithmic(configuration->histogram_logarithmic());
+    d->toggle_histogram_logarithmic(configuration.histogram_logarithmic());
     d->ui->statsWidget->setLayout(new QVBoxLayout);
 }
 
 void HistogramWidget::Private::toggle_histogram_logarithmic(bool logarithmic)
 {
   ui->histogram_logarithmic->setChecked(logarithmic);
-  configuration->set_histogram_logarithmic(logarithmic);
+  configuration.set_histogram_logarithmic(logarithmic);
   histogram->setLogarithmic(logarithmic);
 }
 

--- a/src/widgets/histogramwidget.h
+++ b/src/widgets/histogramwidget.h
@@ -29,7 +29,7 @@ class HistogramWidget : public QWidget
     Q_OBJECT
 public:
 ~HistogramWidget();
-HistogramWidget(const Histogram::ptr &histogram, const Configuration::ptr &configuration, QWidget* parent = 0);
+HistogramWidget(const Histogram::ptr &histogram, Configuration &configuration, QWidget* parent = 0);
 
 private:
     DPTR

--- a/src/widgets/recordingpanel.cpp
+++ b/src/widgets/recordingpanel.cpp
@@ -46,7 +46,7 @@ RecordingPanel::~RecordingPanel()
 {
 }
 
-RecordingPanel::RecordingPanel(const Configuration::ptr & configuration, const FilesystemBrowser::ptr &filesystemBrowser, QWidget* parent)
+RecordingPanel::RecordingPanel(Configuration &configuration, const FilesystemBrowser::ptr &filesystemBrowser, QWidget* parent)
   : QWidget{parent}, dptr(filesystemBrowser, false, this)
 {
   d->ui = make_unique<Ui::RecordingPanel>();
@@ -57,52 +57,52 @@ RecordingPanel::RecordingPanel(const Configuration::ptr & configuration, const F
   });
   
   recording(false);
-  d->ui->save_recording_info->setCurrentIndex( (configuration->save_json_info_file() ? 1 : 0) + (configuration->save_info_file() ? 2 : 0) );
-  d->ui->filePrefix->setCurrentText(configuration->save_file_prefix());
-  d->ui->fileSuffix->setCurrentText(configuration->save_file_suffix());
+  d->ui->save_recording_info->setCurrentIndex( (configuration.save_json_info_file() ? 1 : 0) + (configuration.save_info_file() ? 2 : 0) );
+  d->ui->filePrefix->setCurrentText(configuration.save_file_prefix());
+  d->ui->fileSuffix->setCurrentText(configuration.save_file_suffix());
   static vector<Configuration::SaveFormat> format_combo_index {
     Configuration::SER,
     Configuration::Video,
     Configuration::PNG,
     Configuration::FITS,
   };
-  auto current_format_index = std::find(format_combo_index.begin(), format_combo_index.end(), configuration->save_format());
+  auto current_format_index = std::find(format_combo_index.begin(), format_combo_index.end(), configuration.save_format());
   d->ui->videoOutputType->setCurrentIndex( current_format_index == format_combo_index.end() ? 0 : current_format_index-format_combo_index.begin() );
-  connect(d->ui->videoOutputType, F_PTR(QComboBox, activated, int), [&, configuration](int index) {
-    configuration->set_save_format(format_combo_index[index]);
-    if(format_combo_index[index] == Configuration::Video && !configuration->deprecated_video_warning_shown()) {
-      configuration->set_deprecated_video_warning_shown(true);
+  connect(d->ui->videoOutputType, F_PTR(QComboBox, activated, int), [&](int index) {
+    configuration.set_save_format(format_combo_index[index]);
+    if(format_combo_index[index] == Configuration::Video && !configuration.deprecated_video_warning_shown()) {
+      configuration.set_deprecated_video_warning_shown(true);
       MessagesLogger::instance()->queue(MessagesLogger::Warning, tr("Video encoder"), tr(R"(Saving as video file is not supported, and not recommended.
 Video encoding might fail, due to unavailable codecs, will result in quality loss, and will slow down capture FPS.
 The best file format for planetary imaging is SER. You can also save frames as PNG or TIFF images.)"));
     }
   });
   connect(d->ui->saveDirectory, &QLineEdit::textChanged, [this, &configuration](const QString &directory){
-    configuration->set_save_directory(directory);
+    configuration.set_save_directory(directory);
   });
   
-  d->ui->saveDirectory->setText(configuration->save_directory());
+  d->ui->saveDirectory->setText(configuration.save_directory());
   
   auto is_reloading_prefix_suffix = make_shared<bool>(false);
-  auto change_prefix = [is_reloading_prefix_suffix, &configuration](const QString &prefix){ if(! *is_reloading_prefix_suffix) configuration->set_save_file_prefix(prefix); };
-  auto change_suffix = [is_reloading_prefix_suffix, &configuration](const QString &suffix){ if(! *is_reloading_prefix_suffix) configuration->set_save_file_suffix(suffix); };
+  auto change_prefix = [is_reloading_prefix_suffix, &configuration](const QString &prefix){ if(! *is_reloading_prefix_suffix) configuration.set_save_file_prefix(prefix); };
+  auto change_suffix = [is_reloading_prefix_suffix, &configuration](const QString &suffix){ if(! *is_reloading_prefix_suffix) configuration.set_save_file_suffix(suffix); };
   connect(d->ui->filePrefix, F_PTR(QComboBox, editTextChanged, const QString&), this, change_prefix);
   connect(d->ui->fileSuffix, F_PTR(QComboBox, editTextChanged, const QString&), this, change_suffix);
   
   auto reload_filename_hints = [&,is_reloading_prefix_suffix]{
       *is_reloading_prefix_suffix = true;
       d->ui->filePrefix->clear();
-      d->ui->filePrefix->addItems(configuration->save_file_avail_prefixes());
-      d->ui->filePrefix->setCurrentText(configuration->save_file_prefix());
+      d->ui->filePrefix->addItems(configuration.save_file_avail_prefixes());
+      d->ui->filePrefix->setCurrentText(configuration.save_file_prefix());
       d->ui->fileSuffix->clear();
-      d->ui->fileSuffix->addItems(configuration->save_file_avail_suffixes());
-      d->ui->fileSuffix->setCurrentText(configuration->save_file_suffix());
+      d->ui->fileSuffix->addItems(configuration.save_file_avail_suffixes());
+      d->ui->fileSuffix->setCurrentText(configuration.save_file_suffix());
       *is_reloading_prefix_suffix = false;
 };
   reload_filename_hints();
-  d->ui->limitType->setCurrentIndex(configuration->recording_limit_type());
+  d->ui->limitType->setCurrentIndex(configuration.recording_limit_type());
   connect(d->ui->limitType, F_PTR(QComboBox, activated, int), d->ui->limitsWidgets, &QStackedWidget::setCurrentIndex);
-  connect(d->ui->limitType, F_PTR(QComboBox, activated, int), [&configuration](int index){ configuration->set_recording_limit_type(static_cast<Configuration::RecordingLimit>(index)); });
+  connect(d->ui->limitType, F_PTR(QComboBox, activated, int), [&configuration](int index){ configuration.set_recording_limit_type(static_cast<Configuration::RecordingLimit>(index)); });
   d->ui->limitsWidgets->setCurrentIndex(d->ui->limitType->currentIndex());
   
   connect(d->ui->filename_options, &QPushButton::clicked, [&,reload_filename_hints] {
@@ -116,42 +116,42 @@ The best file format for planetary imaging is SER. You can also save frames as P
       reload_filename_hints();
       dialog->deleteLater();
   });
-  d->ui->saveFramesLimit->setCurrentText(QString::number(configuration->recording_frames_limit()));
+  d->ui->saveFramesLimit->setCurrentText(QString::number(configuration.recording_frames_limit()));
   connect(d->ui->saveFramesLimit, &QComboBox::currentTextChanged, [&configuration](const QString &text){
-      configuration->set_recording_frames_limit(text.toLongLong());
+      configuration.set_recording_frames_limit(text.toLongLong());
   });
   
-  d->ui->duration_limit->setValue(configuration->recording_seconds_limit());
+  d->ui->duration_limit->setValue(configuration.recording_seconds_limit());
   connect(d->ui->duration_limit, F_PTR(QDoubleSpinBox, valueChanged, double), [&configuration](double seconds){
-      configuration->set_recording_seconds_limit(seconds);
+      configuration.set_recording_seconds_limit(seconds);
   });
   
   connect(d->ui->save_recording_info, F_PTR(QComboBox, activated, int), [&configuration](int index) {
     switch(index) {
       case 0:
-        configuration->set_save_info_file(false);
-        configuration->set_save_json_info_file(false);
+        configuration.set_save_info_file(false);
+        configuration.set_save_json_info_file(false);
         break;
       case 1:
-        configuration->set_save_info_file(false);
-        configuration->set_save_json_info_file(true);
+        configuration.set_save_info_file(false);
+        configuration.set_save_json_info_file(true);
         break;
       case 2:
-        configuration->set_save_info_file(true);
-        configuration->set_save_json_info_file(false);
+        configuration.set_save_info_file(true);
+        configuration.set_save_json_info_file(false);
         break;
       case 3:
-        configuration->set_save_info_file(true);
-        configuration->set_save_json_info_file(true);
+        configuration.set_save_info_file(true);
+        configuration.set_save_json_info_file(true);
         break;
     }
   });
   connect(d->ui->start_recording, &QPushButton::clicked, this, &RecordingPanel::start);
   connect(d->ui->stop_recording, &QPushButton::clicked, this, &RecordingPanel::stop);
   connect(d->ui->pause_recording, &QPushButton::toggled, this, &RecordingPanel::setPaused);
-  connect(this, &RecordingPanel::setPaused, this, [=](bool paused) {
+  connect(this, &RecordingPanel::setPaused, this, [=, &configuration](bool paused) {
     d->ui->pause_recording->setIcon(QIcon{paused ? ":/resources/play.png" : ":/resources/pause.png"});
-    if(configuration->recording_pause_stops_timer()) {
+    if(configuration.recording_pause_stops_timer()) {
       if(paused)
         d->recording_elapsed.pause();
       else
@@ -160,28 +160,28 @@ The best file format for planetary imaging is SER. You can also save frames as P
   });
   
   auto pickDirectory = d->ui->saveDirectory->addAction(QIcon(":/resources/folder.png"), QLineEdit::TrailingPosition);
-  connect(pickDirectory, &QAction::triggered, d->filesystemBrowser.get(), [=]{ d->filesystemBrowser->pickDirectory(configuration->save_directory()); });
+  connect(pickDirectory, &QAction::triggered, d->filesystemBrowser.get(), [=, &configuration]{ d->filesystemBrowser->pickDirectory(configuration.save_directory()); });
   connect(d->filesystemBrowser.get(), &FilesystemBrowser::directoryPicked, d->ui->saveDirectory, &QLineEdit::setText);
 
   auto check_directory = [&] {
-    auto saveDir = QDir(configuration->save_directory());
+    auto saveDir = QDir(configuration.save_directory());
     d->ui->start_recording->setEnabled(
-      !configuration->save_directory().isEmpty() && 
+      !configuration.save_directory().isEmpty() &&
       saveDir.exists() && 
       QFileInfo(saveDir.path()).isWritable()
     );
   };
   check_directory();
   connect(d->ui->saveDirectory, &QLineEdit::textChanged, check_directory);
-  connect(d->ui->timelapse, &QCheckBox::toggled, this, [=](bool checked) {
+  connect(d->ui->timelapse, &QCheckBox::toggled, this, [=, &configuration](bool checked) {
     d->ui->timelapse_frame->setVisible(checked);
-    configuration->set_timelapse_mode(checked);
+    configuration.set_timelapse_mode(checked);
   });
-  connect(d->ui->timelapse_duration, &QTimeEdit::timeChanged, this, [=](const QTime &time) {
-    configuration->set_timelapse_msecs(QTime{0,0,0}.msecsTo(time));
+  connect(d->ui->timelapse_duration, &QTimeEdit::timeChanged, this, [=, &configuration](const QTime &time) {
+    configuration.set_timelapse_msecs(QTime{0,0,0}.msecsTo(time));
   });
-  d->ui->timelapse->setChecked(configuration->timelapse_mode());
-  d->ui->timelapse_duration->setTime(QTime{0,0,0}.addMSecs(configuration->timelapse_msecs()));
+  d->ui->timelapse->setChecked(configuration.timelapse_mode());
+  d->ui->timelapse_duration->setTime(QTime{0,0,0}.addMSecs(configuration.timelapse_msecs()));
 
 }
 

--- a/src/widgets/recordingpanel.h
+++ b/src/widgets/recordingpanel.h
@@ -29,7 +29,7 @@ class RecordingPanel : public QWidget
     Q_OBJECT
 public:
     ~RecordingPanel();
-    RecordingPanel(const Configuration::ptr &configuration, const FilesystemBrowser::ptr &filesystemBrowser, QWidget* parent = 0);
+    RecordingPanel(Configuration &configuration, const FilesystemBrowser::ptr &filesystemBrowser, QWidget* parent = 0);
 public slots:
   void recording(bool recording = false, const QString &filename = {});
   void saveFPS(double fps);

--- a/src/widgets/savefileconfiguration.cpp
+++ b/src/widgets/savefileconfiguration.cpp
@@ -30,14 +30,14 @@ DPTR_IMPL(SaveFileConfiguration) {
     unique_ptr<Ui::SaveFileConfiguration> ui;
 };
 
-SaveFileConfiguration::SaveFileConfiguration(const Configuration::ptr & configuration, QWidget* parent) : dptr(this)
+SaveFileConfiguration::SaveFileConfiguration(Configuration &configuration, QWidget* parent) : dptr(this)
 {
     d->ui.reset(new Ui::SaveFileConfiguration);
     d->ui->setupUi(this);
-    d->ui->separator->setText(configuration->save_file_prefix_suffix_separator());
-    connect(d->ui->separator, &QLineEdit::textChanged, bind(&Configuration::set_save_file_prefix_suffix_separator, configuration.get(), _1));
-    d->ui->prefixes->setText(configuration->save_file_avail_prefixes().join(","));
-    d->ui->suffixes->setText(configuration->save_file_avail_suffixes().join(","));
+    d->ui->separator->setText(configuration.save_file_prefix_suffix_separator());
+    connect(d->ui->separator, &QLineEdit::textChanged, bind(&Configuration::set_save_file_prefix_suffix_separator, &configuration, _1));
+    d->ui->prefixes->setText(configuration.save_file_avail_prefixes().join(","));
+    d->ui->suffixes->setText(configuration.save_file_avail_suffixes().join(","));
     auto split = [](const QString &s) {
         QStringList splitted = s.split(",");
         for_each(splitted.begin(), splitted.end(), [](QString &s) { s = s.trimmed(); });
@@ -45,8 +45,8 @@ SaveFileConfiguration::SaveFileConfiguration(const Configuration::ptr & configur
         splitted.erase(remove_if(splitted.begin(), splitted.end(), bind(&QString::isEmpty, _1)), splitted.end());
         return splitted;
     };
-    connect(d->ui->prefixes, &QLineEdit::textChanged, [&, split](const QString &v) { configuration->set_save_file_avail_prefixes(split(v)); });
-    connect(d->ui->suffixes, &QLineEdit::textChanged, [&, split](const QString &v) { configuration->set_save_file_avail_suffixes(split(v)); });
+    connect(d->ui->prefixes, &QLineEdit::textChanged, [&, split](const QString &v) { configuration.set_save_file_avail_prefixes(split(v)); });
+    connect(d->ui->suffixes, &QLineEdit::textChanged, [&, split](const QString &v) { configuration.set_save_file_avail_suffixes(split(v)); });
 }
 
 SaveFileConfiguration::~SaveFileConfiguration()

--- a/src/widgets/savefileconfiguration.h
+++ b/src/widgets/savefileconfiguration.h
@@ -26,7 +26,7 @@ class SaveFileConfiguration : public QWidget
 {
     Q_OBJECT
 public:
-    SaveFileConfiguration(const Configuration::ptr &configuration, QWidget *parent = 0);
+    SaveFileConfiguration(Configuration &configuration, QWidget *parent = 0);
     ~SaveFileConfiguration();
 private:
     DPTR


### PR DESCRIPTION
Passing Configuration object as a reference everywhere, as there is always just one instance in use, existing throughout the entire duration of program execution.

The dialog crash was caused by accessing an object from a lambda, which captured it as a reference to a reference to a shared_ptr.