### PR TITLE
Allow pixel format switch in Format7 modes; handle a control changing its read-only state; allow endianess override

### DIFF
--- a/src/commons/configuration.cpp
+++ b/src/commons/configuration.cpp
@@ -162,6 +162,8 @@ define_setting(filter_presets_by_camera, bool, true)
 define_setting(deprecated_video_warning_shown, bool, false)
 define_setting(recording_pause_stops_timer, bool, false)
 
+define_setting_enum(capture_endianess, Configuration::CaptureEndianess, Configuration::CaptureEndianess::CameraDefault)
+
 QString Configuration::savefile() const
 {
   QMap<SaveFormat, QString> extension {

--- a/src/commons/configuration.h
+++ b/src/commons/configuration.h
@@ -107,6 +107,10 @@ public:
     declare_setting(deprecated_video_warning_shown, bool)
     declare_setting(recording_pause_stops_timer, bool)
     
+    /// Defines how to interpret multi-byte data coming from camera (CameraDefault = as reported by the camera; may be unreliable)
+    enum class CaptureEndianess { CameraDefault, Little, Big };
+    declare_setting(capture_endianess, CaptureEndianess)
+
     struct Preset {
       QString path;
       QString name;

--- a/src/commons/frame.cpp
+++ b/src/commons/frame.cpp
@@ -133,4 +133,7 @@ Frame::ByteOrder Frame::byteOrder() const
   return d->byteOrder;
 }
 
-
+void Frame::overrideByteOrder(ByteOrder byteOrder)
+{
+    d->byteOrder = byteOrder;
+}

--- a/src/commons/frame.h
+++ b/src/commons/frame.h
@@ -58,6 +58,7 @@ public:
   typedef std::chrono::duration<double> Seconds;
   Seconds exposure() const;
   void set_exposure(const Seconds &exposure);
+  void overrideByteOrder(ByteOrder byteOrder);
 private:
   DPTR
 };

--- a/src/drivers/iidc/iidc_worker.cpp
+++ b/src/drivers/iidc/iidc_worker.cpp
@@ -22,13 +22,17 @@
 
 
 IIDCImagerWorker::IIDCImagerWorker(dc1394camera_t *_camera, dc1394video_mode_t _vidMode,
-                                   const QRect &roi)
-: camera(_camera), nativeFrame(nullptr), vidMode(_vidMode)
+                                   dc1394color_coding_t _pixFmt, const QRect &roi)
+: camera(_camera), nativeFrame(nullptr), vidMode(_vidMode), pixFmt(_pixFmt)
 {
     frameInfo.initialized = false;
 
     IIDC_CHECK << dc1394_video_set_mode(camera, vidMode)
                << "Set video mode";
+
+    if (dc1394_is_video_mode_scalable(vidMode))
+        IIDC_CHECK << dc1394_format7_set_color_coding(camera, vidMode, pixFmt)
+                   << "Format7 set color coding";
 
     qDebug() << "Requested to set ROI to " << roi.x() << ", " << roi.y() << ", " << roi.width() << ", " << roi.height();
 
@@ -197,3 +201,4 @@ void IIDCImagerWorker::setROI(const QRect &roi)
                    << "Set ROI";
     }
 }
+

--- a/src/drivers/iidc/iidc_worker.h
+++ b/src/drivers/iidc/iidc_worker.h
@@ -29,6 +29,7 @@ class IIDCImagerWorker: public ImagerThread::Worker
     dc1394camera_t *camera;
     dc1394video_frame_t *nativeFrame; ///< The most recently captured frame
     dc1394video_mode_t vidMode;
+    dc1394color_coding_t pixFmt;
 
     struct
     {
@@ -60,7 +61,7 @@ public:
 
     static constexpr uint32_t NUM_DMA_BUFFERS = 4;
 
-    IIDCImagerWorker(dc1394camera_t *_camera, dc1394video_mode_t _vidMode,
+    IIDCImagerWorker(dc1394camera_t *_camera, dc1394video_mode_t _vidMode, dc1394color_coding_t _pixFmt,
                      /// Must be already validated; also used as the initial frame size for Format7 modes
                      const QRect &roi);
 

--- a/src/drivers/imager.h
+++ b/src/drivers/imager.h
@@ -20,6 +20,7 @@
 #define PL_IMG_IMAGER_H
 
 #include <memory>
+#include <commons/configuration.h>
 #include <chrono>
 #include <QObject>
 #include <QDebug>
@@ -45,6 +46,8 @@ public:
   virtual Properties properties() const = 0;
   bool supports(Capability capability) const;
   
+  void setCaptureEndianess(Configuration::CaptureEndianess captureEndianess);
+
 protected:
   void restart(const ImagerThread::Worker::factory &worker);
   std::shared_ptr<QWaitCondition> push_job_on_thread(const ImagerThread::Job &job);

--- a/src/drivers/imagerthread.h
+++ b/src/drivers/imagerthread.h
@@ -18,6 +18,8 @@
 
 #ifndef IMAGERTHREAD_H
 #define IMAGERTHREAD_H
+
+#include <commons/configuration.h>
 #include <functional>
 #include "image_handlers/imagehandler.h"
 #include "dptr.h"
@@ -36,12 +38,13 @@ class ImagerThread
     typedef std::shared_ptr<Worker> ptr;
     typedef std::function<ptr()> factory;
   };
-  ImagerThread(const Worker::ptr& worker, Imager* imager, const ImageHandler::ptr& imageHandler);
+  ImagerThread(const Worker::ptr& worker, Imager* imager, const ImageHandler::ptr& imageHandler, Configuration::CaptureEndianess captureEndianess);
   ~ImagerThread();
   void stop();
   void start();
   std::shared_ptr<QWaitCondition> push_job(const Job &job);
   void set_exposure(const std::chrono::duration<double> &exposure);
+  void setCaptureEndianess(Configuration::CaptureEndianess captureEndianess);
 private:
   DPTR
 

--- a/src/image_handlers/backend/local_saveimages.cpp
+++ b/src/image_handlers/backend/local_saveimages.cpp
@@ -287,7 +287,7 @@ LocalSaveImages::~LocalSaveImages()
 }
 
 
-void LocalSaveImages::handle(const Frame::ptr &frame)
+void LocalSaveImages::doHandle(Frame::ptr frame)
 {
   d->worker->queue(frame);
 //   QtConcurrent::run(bind(&WriterThreadWorker::handle, d->worker, frame));

--- a/src/image_handlers/backend/local_saveimages.h
+++ b/src/image_handlers/backend/local_saveimages.h
@@ -29,12 +29,14 @@ class LocalSaveImages : public SaveImages
 public:
     LocalSaveImages(Configuration &configuration, QObject *parent = 0);
     ~LocalSaveImages();
-    virtual void handle(const Frame::ptr &frame);
 public slots:
   void startRecording(Imager *imager);
   void endRecording();
   void setPaused(bool paused);
 private:
+
+  void doHandle(Frame::ptr frame) override;
+
   DPTR
 };
 

--- a/src/image_handlers/frontend/displayimage.cpp
+++ b/src/image_handlers/frontend/displayimage.cpp
@@ -144,7 +144,7 @@ void DisplayImage::read_settings()
 }
 
 
-void DisplayImage::handle( const Frame::ptr &frame )
+void DisplayImage::doHandle(Frame::ptr frame)
 {
   if( ! d->should_display_frame()  || !frame->mat().data ) {
     return;

--- a/src/image_handlers/frontend/displayimage.h
+++ b/src/image_handlers/frontend/displayimage.h
@@ -30,7 +30,6 @@ Q_OBJECT
 public:
     ~DisplayImage();
     DisplayImage(const Configuration &configuration, QObject* parent = 0);
-    virtual void handle(const Frame::ptr &frame);
     void setRecording(bool recording);
     QRect imageRect() const;
 signals:
@@ -44,6 +43,9 @@ public slots:
   void quit();
   void read_settings();
 private:
+
+  void doHandle(Frame::ptr frame) override;
+
   DPTR
 };
 

--- a/src/image_handlers/frontend/histogram.cpp
+++ b/src/image_handlers/frontend/histogram.cpp
@@ -86,7 +86,7 @@ Histogram::Histogram(const Configuration &configuration, QObject* parent) : QObj
   }
 }
 
-void Histogram::handle(const Frame::ptr &frame)
+void Histogram::doHandle(Frame::ptr frame)
 {
   if( ! d->should_read_frame() )
     return;

--- a/src/image_handlers/frontend/histogram.h
+++ b/src/image_handlers/frontend/histogram.h
@@ -37,7 +37,6 @@ public:
   };
   ~Histogram();
   Histogram(const Configuration &configuration, QObject* parent = 0);
-  virtual void handle(const Frame::ptr &frame);
   void set_bins(std::size_t bins_size);
   void setRecording(bool recording);
   void setLogarithmic(bool logarithmic);
@@ -48,6 +47,9 @@ public slots:
 signals:
   void histogram(const QImage &, const QMap<Histogram::Channel, QVariantMap> &, Histogram::Channel channel);
 private:
+
+  void doHandle(Frame::ptr frame) override;
+
   DPTR
 };
 

--- a/src/image_handlers/imagehandler.h
+++ b/src/image_handlers/imagehandler.h
@@ -20,13 +20,16 @@
 
 #include <memory>
 #include <QList>
-#include<algorithm>
+#include <algorithm>
 #include "commons/frame.h"
 
 class ImageHandler {
+protected:
+    virtual void doHandle(Frame::ptr frame) = 0;
+
 public:
   typedef std::shared_ptr<ImageHandler> ptr;
-  virtual void handle(const Frame::ptr &frame) = 0;
+  void handle(Frame::ptr frame) { doHandle(frame); }
 };
 
 class ImageHandlers : public ImageHandler {
@@ -34,13 +37,15 @@ public:
   typedef std::shared_ptr<ImageHandlers> ptr;
   ImageHandlers(const QList<ImageHandler::ptr> &handlers = {}) : handlers{handlers} {}
   
-  virtual void handle(const Frame::ptr &frame) {
-    for(auto handler: handlers)
-      handler->handle(frame);
-  }
   void push_back(const ImageHandler::ptr &handler) { handlers.push_back(handler); }
   void clear() { handlers.clear(); }
 private:
+
+  void doHandle(Frame::ptr frame) override {
+    for(auto handler: handlers)
+      handler->handle(frame);
+  }
+
   QList<ImageHandler::ptr> handlers;
 };
 #endif

--- a/src/image_handlers/output_writers/cvvideowriter.cpp
+++ b/src/image_handlers/output_writers/cvvideowriter.cpp
@@ -46,7 +46,7 @@ QString cvVideoWriter::filename() const
   return d->filename;
 }
 
-void cvVideoWriter::handle ( const Frame::ptr &frame )
+void cvVideoWriter::doHandle(Frame::ptr frame)
 {
   auto fourcc = [](const string &s) { return CV_FOURCC(s[0], s[1], s[2], s[3]); };
   auto size = cv::Size{frame->mat().cols, frame->mat().rows};

--- a/src/image_handlers/output_writers/cvvideowriter.h
+++ b/src/image_handlers/output_writers/cvvideowriter.h
@@ -28,9 +28,11 @@ public:
  cvVideoWriter(const Configuration &configuration);
  ~cvVideoWriter();
  QString filename() const override;
- void handle(const Frame::ptr &frame) override;
 
 private:
+
+    void doHandle(Frame::ptr frame) override;
+
     DPTR
 };
 

--- a/src/image_handlers/output_writers/filewriter.h
+++ b/src/image_handlers/output_writers/filewriter.h
@@ -28,7 +28,6 @@ class FileWriter : public ImageHandler {
 public:
   typedef std::shared_ptr<FileWriter> Ptr;
   typedef std::function<Ptr(const QString &deviceName, const Configuration *configuration)> Factory;
-  virtual void handle(const Frame::ptr &frame) = 0;
   virtual QString filename() const = 0;
   static QMap<Configuration::SaveFormat, Factory> factories();
 };

--- a/src/image_handlers/output_writers/imagefilewriter.cpp
+++ b/src/image_handlers/output_writers/imagefilewriter.cpp
@@ -62,7 +62,7 @@ ImageFileWriter::~ImageFileWriter()
 }
 
 
-void ImageFileWriter::handle(const Frame::ptr& frame)
+void ImageFileWriter::doHandle(Frame::ptr frame)
 {
   if(d->writer)
     d->writer(frame);

--- a/src/image_handlers/output_writers/imagefilewriter.h
+++ b/src/image_handlers/output_writers/imagefilewriter.h
@@ -27,9 +27,11 @@ public:
   enum Format {PNG, FITS};
   ImageFileWriter(Format format, const Configuration &configuration);
   QString filename() const override;
-  void handle(const Frame::ptr & frame) override;
   ~ImageFileWriter();
 private:
+
+    void doHandle(Frame::ptr frame) override;
+
   DPTR
 };
 

--- a/src/image_handlers/output_writers/serwriter.cpp
+++ b/src/image_handlers/output_writers/serwriter.cpp
@@ -81,7 +81,7 @@ QString SERWriter::filename() const
   return d->file.fileName();
 }
 
-void SERWriter::handle ( const Frame::ptr &frame )
+void SERWriter::doHandle(Frame::ptr frame)
 {
   if(! d->header->imageWidth) {
     d->header->endian = (frame->byteOrder() == Frame::BigEndian ? SER_Header::BigEndian : SER_Header::LittleEndian);

--- a/src/image_handlers/output_writers/serwriter.h
+++ b/src/image_handlers/output_writers/serwriter.h
@@ -28,9 +28,11 @@ public:
  SERWriter(const QString &deviceName, const Configuration &configuration);
  ~SERWriter();
  QString filename() const override;
- void handle(const Frame::ptr &frame) override;
 
 private:
+
+    void doHandle(Frame::ptr frame) override;
+
    DPTR
 };
 

--- a/src/image_handlers/saveimages.h
+++ b/src/image_handlers/saveimages.h
@@ -32,7 +32,7 @@ public:
   class Error;
     SaveImages(QObject *parent = 0);
     virtual ~SaveImages();
-    virtual void handle(const Frame::ptr &frame) = 0;
+
 public slots:
   virtual void startRecording(Imager *imager) = 0;
   virtual void endRecording() = 0;

--- a/src/image_handlers/threadimagehandler.cpp
+++ b/src/image_handlers/threadimagehandler.cpp
@@ -28,12 +28,13 @@ DPTR_IMPL(ThreadImageHandler) {
   unique_ptr<Worker> worker;
 };
 
-class ThreadImageHandler::Private::Worker : public QObject, public ImageHandler {
+class ThreadImageHandler::Private::Worker : public QObject {
   Q_OBJECT
+
 public:
   Worker(const ImageHandler::ptr &imageHandler, QObject *parent = nullptr);
 public slots:
-  virtual void handle(const Frame::ptr &frame);
+  void handle(Frame::ptr frame);
 private:
   ImageHandler::ptr imageHandler;
 };
@@ -44,7 +45,7 @@ ThreadImageHandler::Private::Worker::Worker(const ImageHandler::ptr& imageHandle
 }
 
 
-void ThreadImageHandler::Private::Worker::handle(const Frame::ptr& frame)
+void ThreadImageHandler::Private::Worker::handle(Frame::ptr frame)
 {
   imageHandler->handle(frame);
 }
@@ -63,7 +64,7 @@ ThreadImageHandler::~ThreadImageHandler()
   d->thread->wait();
 }
 
-void ThreadImageHandler::handle(const Frame::ptr& frame)
+void ThreadImageHandler::doHandle(Frame::ptr frame)
 {
   QMetaObject::invokeMethod(d->worker.get(), "handle", Qt::QueuedConnection, Q_ARG(Frame::ptr, frame));
 }

--- a/src/image_handlers/threadimagehandler.h
+++ b/src/image_handlers/threadimagehandler.h
@@ -27,8 +27,11 @@ class ThreadImageHandler : public ImageHandler
 public:
   ThreadImageHandler(const  ImageHandler::ptr &imageHandler);
   virtual ~ThreadImageHandler();
-  virtual void handle(const Frame::ptr &frame);
+
 private:
+
+  void doHandle(Frame::ptr frame) override;
+
   DPTR
 };
 

--- a/src/network/client/remotesaveimages.cpp
+++ b/src/network/client/remotesaveimages.cpp
@@ -50,10 +50,6 @@ void RemoteSaveImages::endRecording()
   dispatcher()->queue_send(SaveFileProtocol::packetEndRecording());
 }
 
-void RemoteSaveImages::handle(const Frame::ptr& frame)
-{
-}
-
 void RemoteSaveImages::setPaused(bool paused)
 {
   dispatcher()->queue_send(SaveFileProtocol::setPaused(paused));

--- a/src/network/client/remotesaveimages.h
+++ b/src/network/client/remotesaveimages.h
@@ -29,12 +29,15 @@ Q_OBJECT
 public:
   RemoteSaveImages(const NetworkDispatcher::ptr &dispatcher);
   ~RemoteSaveImages();
-  void handle(const Frame::ptr & frame) override;
+
 public slots:
   void startRecording(Imager * imager) override;
   void endRecording() override;
   void setPaused(bool paused) override;
 private:
+
+  void doHandle(Frame::ptr frame) override { }
+
   DPTR
 };
 

--- a/src/network/server/framesforwarder.cpp
+++ b/src/network/server/framesforwarder.cpp
@@ -42,7 +42,7 @@ FramesForwarder::~FramesForwarder()
 {
 }
 
-void FramesForwarder::handle(const Frame::ptr& frame)
+void FramesForwarder::doHandle(Frame::ptr frame)
 {
   if(! DriverProtocol::isForwardingEnabled() || d->elapsed.elapsed() < (d->recording ? 2000 : 50 ) || ! d->enabled) // TODO: variable rate, depending on network delay?
     return;

--- a/src/network/server/framesforwarder.h
+++ b/src/network/server/framesforwarder.h
@@ -29,9 +29,11 @@ public:
   typedef std::shared_ptr<FramesForwarder> ptr;
   FramesForwarder(const NetworkDispatcher::ptr &dispatcher);
   ~FramesForwarder();
-  void handle(const Frame::ptr & frame) override;
   bool enabled() const;
 private:
+
+  void doHandle(Frame::ptr frame) override;
+
   DPTR
 public slots:
   void setEnabled(bool enabled);

--- a/src/planetaryimager.cpp
+++ b/src/planetaryimager.cpp
@@ -102,6 +102,7 @@ void PlanetaryImager::open(const Driver::Camera::ptr& camera)
   auto openImager = [this, camera] {
     try {
       auto imager = camera->imager(d->imageHandler);
+      imager->setCaptureEndianess(d->configuration.capture_endianess());
       imager->moveToThread(this->thread());
       imager->setParent(this);
       return imager;

--- a/src/planetaryimager_mainwindow.cpp
+++ b/src/planetaryimager_mainwindow.cpp
@@ -208,6 +208,12 @@ PlanetaryImagerMainWindow::PlanetaryImagerMainWindow(
 
     connect(d->configurationDialog, &QDialog::accepted, this, bind(&DisplayImage::read_settings, d->displayImage), Qt::DirectConnection);
     connect(d->configurationDialog, &QDialog::accepted, this, bind(&Histogram::read_settings, d->histogram), Qt::DirectConnection);
+    connect(d->configurationDialog, &QDialog::accepted, this,
+            [this]() {
+                auto *imager = d->planetaryImager->imager();
+                if (imager) imager->setCaptureEndianess(d->planetaryImager->configuration().capture_endianess());
+            });
+
     connect(d->recording_panel, &RecordingPanel::start, [=]{d->planetaryImager->saveImages()->startRecording(d->imager);});
     connect(d->recording_panel, &RecordingPanel::stop, bind(&SaveImages::endRecording, d->planetaryImager->saveImages()));
     connect(d->recording_panel, &RecordingPanel::setPaused, bind(&SaveImages::setPaused, d->planetaryImager->saveImages(), _1));

--- a/src/widgets/cameracontrolswidget.cpp
+++ b/src/widgets/cameracontrolswidget.cpp
@@ -160,6 +160,9 @@ void CameraControl::control_updated(const Imager::Control& changed_control)
   if(changed_control.supports_auto) {
     auto_changed(changed_control.value_auto);
   }
+  control_widget->setEnabled(!changed_control.readonly
+                             && (!changed_control.supports_auto  || !changed_control.value_auto)
+                             && (!changed_control.supports_onOff || changed_control.value_onOff));
   control_changed_led->setPixmap(is_expected_value ? green_dot : red_dot);
   control_changed_led->show();
   QTimer::singleShot(5000, this, [this]{ control_changed_led->hide(); });

--- a/src/widgets/configurationdialog.cpp
+++ b/src/widgets/configurationdialog.cpp
@@ -177,4 +177,12 @@ ConfigurationDialog::ConfigurationDialog(Configuration &configuration, QWidget* 
         QMessageBox::information(this, tr("Restart required"), tr("You changed the OpenGL setting. Please restart PlanetaryImage for this change to take effect"));
       }
     });
+
+    d->ui->pixelDataEndianess->addItem("camera default", static_cast<int>(Configuration::CaptureEndianess::CameraDefault));
+    d->ui->pixelDataEndianess->addItem("little-endian",  static_cast<int>(Configuration::CaptureEndianess::Little));
+    d->ui->pixelDataEndianess->addItem("big-endian",     static_cast<int>(Configuration::CaptureEndianess::Big));
+    d->ui->pixelDataEndianess->setCurrentIndex(static_cast<int>(d->configuration.capture_endianess()));
+
+    connect(d->ui->pixelDataEndianess, F_PTR(QComboBox, activated, int),
+            [=](int index) { d->configuration.set_capture_endianess(static_cast<Configuration::CaptureEndianess>(d->ui->pixelDataEndianess->itemData(index).toInt())); });
 }

--- a/src/widgets/configurationdialog.ui
+++ b/src/widgets/configurationdialog.ui
@@ -6,18 +6,28 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>486</width>
-    <height>496</height>
+    <width>839</width>
+    <height>833</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Configuration</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QTabWidget" name="configurationTab">
      <property name="currentIndex">
-      <number>1</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -345,7 +355,7 @@
        <item>
         <widget class="QLabel" name="label_4">
          <property name="text">
-          <string>Edge detection algorythm</string>
+          <string>Edge detection algorithm</string>
          </property>
         </widget>
        </item>
@@ -549,6 +559,26 @@
         </widget>
        </item>
        <item>
+        <layout class="QFormLayout" name="formLayout">
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_22">
+           <property name="toolTip">
+            <string>Endianess of multi-byte pixel values received from camera</string>
+           </property>
+           <property name="text">
+            <string>Pixel data endianess:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="pixelDataEndianess"/>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -563,16 +593,6 @@
        </item>
       </layout>
      </widget>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
-     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
* All pixel formats of a Format7 mode are now reported and selectable
* If capture data endianess reported by camera is invalid, the user can override it in the Configuration dialog (applies to all drivers)