### PR TITLE
Fixes for endianess ASICAM/SER Output

### DIFF
--- a/src/drivers/zwo_asi/asiimagingworker.cpp
+++ b/src/drivers/zwo_asi/asiimagingworker.cpp
@@ -82,8 +82,8 @@ void ASIImagingWorker::calc_exposure_timeout()
 
 Frame::ptr ASIImagingWorker::shoot()
 {
-  // TODO: verify if Frame byteorder is always BigEndian for ASI cameras
-  auto frame = make_shared<Frame>( d->format == ASI_IMG_RAW16 ? 16 : 8,  d->colorFormat(), QSize{d->roi.width(), d->roi.height()}, Frame::BigEndian);
+  // ASI CAMs are little endian
+  auto frame = make_shared<Frame>( d->format == ASI_IMG_RAW16 ? 16 : 8,  d->colorFormat(), QSize{d->roi.width(), d->roi.height()}, Frame::LittleEndian);
   ASI_CHECK << ASIGetVideoData(d->info.CameraID, frame->data(), frame->size(), d->exposure_timeout) << "Capture frame";
   return frame;
 }

--- a/src/image_handlers/output_writers/serwriter.cpp
+++ b/src/image_handlers/output_writers/serwriter.cpp
@@ -83,7 +83,9 @@ QString SERWriter::filename() const
 void SERWriter::doHandle(Frame::ptr frame)
 {
   if(! d->header->imageWidth) {
-    d->header->endian = (frame->byteOrder() == Frame::BigEndian ? SER_Header::BigEndian : SER_Header::LittleEndian);
+      // Force incorrect ENDIAN Type for compatibility with most readers ...
+    // d->header->endian = (frame->byteOrder() == Frame::BigEndian ? SER_Header::BigEndian : SER_Header::LittleEndian);
+    d->header->endian = (frame->byteOrder() == Frame::BigEndian ? SER_Header::LittleEndian : SER_Header::BigEndian);
     d->header->set_color_format(frame->colorFormat());
     d->header->pixelDepth = frame->bpp();
     qDebug() << "SER PixelDepth set to " << d->header->pixelDepth << "bpp" << ", bytesPerPixels: " << d->header->bytesPerPixel();


### PR DESCRIPTION
correct endianess for ASI cameras
SER writer now set "opposite" endianess in header. Most readers have implemented the specs incorrectly.  