### PR TITLE
On startup, scan for cameras just once

### DIFF
--- a/src/planetaryimager.cpp
+++ b/src/planetaryimager.cpp
@@ -142,8 +142,10 @@ void PlanetaryImager::Private::initDevicesWatcher()
   }
   if(usbfsdir.isEmpty())
     return;
+
+  static QStringList entries = QDir(usbfsdir).entryList();
+
   connect(notifyTimer, &QTimer::timeout, [=]{
-    static QStringList entries;
     auto current = QDir(usbfsdir).entryList();
     if(current != entries) {
       qDebug() << "usb devices changed";


### PR DESCRIPTION
Fixes a problem with CM3-U3-13S2M-CS camera on kernel 4.13.16-100: when connecting via USB 2 using FlyCapture2, camera context can be only opened twice (if streaming is not started) - that's what happens during scan. Subsequent attempts cause a low-level hang (`libusb`?) and the camera has to be reconnected. Interestingly, there's no problem on USB 3 or when using IIDC.

With this change, after just one initial scan, streaming can be started/stopped multiple times.