### PR TITLE
Fix crash on startup with no OpenGL support

### DIFF
--- a/src/planetaryimager_mainwindow.cpp
+++ b/src/planetaryimager_mainwindow.cpp
@@ -156,7 +156,12 @@ PlanetaryImagerMainWindow::PlanetaryImagerMainWindow(
     d->ui->image->layout()->addWidget(d->image_widget = new ZoomableImage(false));
 #ifdef HAVE_QT5_OPENGL // TODO: make configuration item
     if(d->planetaryImager->configuration().opengl())
-      d->image_widget->setOpenGL();
+    {
+      if (!QGLFormat::hasOpenGL())
+          qWarning() << "Window system does not support OpenGL.";
+      else
+          d->image_widget->setOpenGL();
+    }
 #endif
     d->image_widget->scene()->setBackgroundBrush(QBrush{Qt::black, Qt::Dense4Pattern});
     connect(d->image_widget, &ZoomableImage::zoomLevelChanged, d->statusbar_info_widget, &StatusBarInfoWidget::zoom);


### PR DESCRIPTION
Prevents startup problem on e.g. Ubuntu@Odroid or Raspbian@RPi3.
Fixes #47.