### PR TITLE
OSX Dependencies fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,12 @@ if(static_qt_windows)
 add_definitions(-DSTATIC_WINDOWS_PLUGIN)
 endif()
 
-set(drivers_destination ${APPBUNDLE_INSTALL_PREFIX}lib/${CMAKE_PROJECT_NAME}/drivers)
+if(OSX_BUNDLE)
+    set(drivers_destination ${APPBUNDLE_INSTALL_PREFIX}/Contents/Plugins/${CMAKE_PROJECT_NAME})
+else()
+    set(drivers_destination ${APPBUNDLE_INSTALL_PREFIX}lib/${CMAKE_PROJECT_NAME}/drivers)
+endif()
+
 set(binary_destination bin)
 set(CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
@@ -16,14 +21,15 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   add_definitions(-DDRIVERS_DIRECTORY="${drivers_destination}")
 else()
   if(OSX_BUNDLE)
-      add_definitions(-DDRIVERS_DIRECTORY="../../lib/PlanetaryImager/drivers")
+      add_definitions(-DDRIVERS_DIRECTORY="../Plugins/${CMAKE_PROJECT_NAME}")
+      set(CMAKE_INSTALL_RPATH "@executable_path/../Frameworks" "@executable_path/../../Frameworks")
   else()
       add_definitions(-DDRIVERS_DIRECTORY="${CMAKE_INSTALL_PREFIX}/${drivers_destination}")
   endif()
 endif()
 
 
-SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${drivers_destination};$ORIGIN")
+
 
 if(ADD_DRIVERS_BUILD_DIRECTORY)
   add_definitions(-DADDITIONAL_DRIVERS_DIRECTORY="${CMAKE_CURRENT_BINARY_DIR}/drivers")

--- a/src/bundle_install/CMakeLists.txt
+++ b/src/bundle_install/CMakeLists.txt
@@ -1,5 +1,5 @@
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/macdeployqt ${CMAKE_CURRENT_BINARY_DIR}/macdeployqt)
-install(CODE "
-execute_process(COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/macdeployqt ${MACOSX_BUNDLE_BUNDLE_NAME}.app WORKING_DIRECTORY \$ENV\{DESTDIR\} )
-")
+# install(CODE "
+# execute_process(COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/macdeployqt ${MACOSX_BUNDLE_BUNDLE_NAME}.app WORKING_DIRECTORY \$ENV\{DESTDIR\} )
+# ")
 

--- a/src/bundle_install/CMakeLists.txt
+++ b/src/bundle_install/CMakeLists.txt
@@ -1,5 +1,9 @@
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/macdeployqt ${CMAKE_CURRENT_BINARY_DIR}/macdeployqt)
-# install(CODE "
-# execute_process(COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/macdeployqt ${MACOSX_BUNDLE_BUNDLE_NAME}.app WORKING_DIRECTORY \$ENV\{DESTDIR\} )
-# ")
+install(CODE "
+set(BUNDLE_PATH \$ENV\{DESTDIR\})
+message(\"Running ${CMAKE_CURRENT_BINARY_DIR}/macdeployqt ${MACOSX_BUNDLE_BUNDLE_NAME}.app WORKING_DIRECTORY \${BUNDLE_PATH}\")
+execute_process(COMMAND bash ${CMAKE_CURRENT_BINARY_DIR}/macdeployqt ${MACOSX_BUNDLE_BUNDLE_NAME}.app WORKING_DIRECTORY \${BUNDLE_PATH} )
+message(\"Running ${CMAKE_SOURCE_DIR}/support/osx/fix_libraries.py WORKING_DIRECTORY \${BUNDLE_PATH}/${MACOSX_BUNDLE_BUNDLE_NAME}.app/Contents/Frameworks\")
+execute_process(COMMAND python ${CMAKE_SOURCE_DIR}/support/osx/fix_libraries.py WORKING_DIRECTORY \${BUNDLE_PATH}/${MACOSX_BUNDLE_BUNDLE_NAME}.app/Contents/Frameworks )
+")
 

--- a/support/osx/fix_libraries.py
+++ b/support/osx/fix_libraries.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import os
+import sys
+import subprocess
+import argparse
+import shutil
+
+parser = argparse.ArgumentParser(description='Fix libraries path in an application/library')
+parser.add_argument('--otool', default='otool')
+parser.add_argument('--install-name-tool', default='install_name_tool')
+parser.add_argument('files', nargs='*')
+
+args = parser.parse_args()
+
+brew_prefix = subprocess.check_output(['brew', '--prefix']).decode().strip()
+
+def is_brew_dependency(library):
+    if os.path.basename(library).startswith('Qt'):
+        return False
+    if library.startswith(brew_prefix):
+        return True
+    return False
+
+def dependencies(file):
+    deps = [
+        x.strip().split(' (')[0] for x in
+        subprocess.check_output([args.otool, '-L', file]).decode().split('\n')[1:]
+        if x
+    ]
+    deps = [d for d in deps if is_brew_dependency(d)]
+    return deps
+
+def fix_dependencies(file):
+    for library in dependencies(file):
+        libname = os.path.basename(library)
+        print('fixing library {}: add rpath for dependency {}'.format(file, libname))
+        result = subprocess.call([args.install_name_tool, '-change', library, '@rpath/{0}'.format(libname), file])
+
+files = args.files
+if not files:
+    print('Looking for libraries in {}'.format(os.getcwd()))
+    files = [os.path.join(os.getcwd(), x) for x in os.listdir('.') if x.endswith('.dylib')]
+
+for file in files:
+    fix_dependencies(file)

--- a/support/osx/install-deps
+++ b/support/osx/install-deps
@@ -7,7 +7,7 @@ if ! which brew &>/dev/null; then
     exit 1
 fi
 
-for pkg in qt opencv pkg-config cmake boost cfitsio; do
+for pkg in libusb wget qt opencv pkg-config cmake boost cfitsio libdc1394; do
     if ! brew list "$pkg" &>/dev/null; then
         brew install "$pkg"
     fi


### PR DESCRIPTION
OSX automated builds were created with wrong dependencies inside the bundle.
This PR fixes it by:
 - Adding the correct `rpath` to the executable and driver libraries
 - runs a python script to always use `rpath` inside the libraries copied into the `Frameworks` bundle directory.
Additionally, it changes the path for the deployed driver libraries in order to get a more consistant bundle structure.