### PR TITLE
Fix Debian Stretch and Buster dependencies

### DIFF
--- a/support/docker/files/configuration-debian-buster.cmake
+++ b/support/docker/files/configuration-debian-buster.cmake
@@ -1,3 +1,3 @@
 include(${CMAKE_CURRENT_LIST_DIR}/configuration-debian-base.cmake)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libusb-1.0-0, libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc3.2, libopencv-core3.2, libopencv-highgui3.2, fxload, libccfits0v5" CACHE STRING "")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libusb-1.0-0, libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc3.2, libopencv-core3.2, libopencv-highgui3.2, fxload, libccfits0v5, libopencv-shape3.2, libopencv-stitching3.2, libopencv-superres3.2, libopencv-videostab3.2, libopencv-contrib3.2, libqt5qml5" CACHE STRING "")
 set(EXTRA_LIBRARIES udev CACHE STRING "")

--- a/support/docker/files/configuration-debian-buster.cmake
+++ b/support/docker/files/configuration-debian-buster.cmake
@@ -1,3 +1,3 @@
 include(${CMAKE_CURRENT_LIST_DIR}/configuration-debian-base.cmake)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libusb-1.0-0, libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc3.2, libopencv-core3.2, libopencv-highgui3.2, fxload, libccfits0v5, libopencv-shape3.2, libopencv-stitching3.2, libopencv-superres3.2, libopencv-videostab3.2, libopencv-contrib3.2, libqt5qml5" CACHE STRING "")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc3.2, libopencv-core3.2, libopencv-highgui3.2, libccfits0v5, libopencv-shape3.2, libopencv-stitching3.2, libopencv-superres3.2, libopencv-videostab3.2, libopencv-contrib3.2, libqt5qml5" CACHE STRING "")
 set(EXTRA_LIBRARIES udev CACHE STRING "")

--- a/support/docker/files/configuration-debian-jessie.cmake
+++ b/support/docker/files/configuration-debian-jessie.cmake
@@ -1,3 +1,3 @@
 include(${CMAKE_CURRENT_LIST_DIR}/configuration-debian-base.cmake)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libusb-1.0-0, libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc2.4, libopencv-core2.4, libopencv-highgui2.4, fxload, libccfits0" CACHE STRING "")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc2.4, libopencv-core2.4, libopencv-highgui2.4, libccfits0" CACHE STRING "")
 set(EXTRA_LIBRARIES udev CACHE STRING "")

--- a/support/docker/files/configuration-debian-stretch.cmake
+++ b/support/docker/files/configuration-debian-stretch.cmake
@@ -1,3 +1,3 @@
 include(${CMAKE_CURRENT_LIST_DIR}/configuration-debian-base.cmake)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libusb-1.0-0, libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc2.4v5, libopencv-core2.4v5, libopencv-highgui2.4-deb0, fxload, libccfits0v5" CACHE STRING "")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc2.4v5, libopencv-core2.4v5, libopencv-highgui2.4-deb0, fxload, libccfits0v5, libopencv-videostab2.4v5, libopencv-ts2.4v5, libopencv-superres2.4v5, libopencv-stitching2.4v5, libopencv-contrib2.4v5, libqt5qml5" CACHE STRING "")
 set(EXTRA_LIBRARIES udev CACHE STRING "")

--- a/support/docker/files/configuration-debian-stretch.cmake
+++ b/support/docker/files/configuration-debian-stretch.cmake
@@ -1,3 +1,3 @@
 include(${CMAKE_CURRENT_LIST_DIR}/configuration-debian-base.cmake)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc2.4v5, libopencv-core2.4v5, libopencv-highgui2.4-deb0, fxload, libccfits0v5, libopencv-videostab2.4v5, libopencv-ts2.4v5, libopencv-superres2.4v5, libopencv-stitching2.4v5, libopencv-contrib2.4v5, libqt5qml5" CACHE STRING "")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc2.4v5, libopencv-core2.4v5, libopencv-highgui2.4-deb0, libccfits0v5, libopencv-videostab2.4v5, libopencv-ts2.4v5, libopencv-superres2.4v5, libopencv-stitching2.4v5, libopencv-contrib2.4v5, libqt5qml5" CACHE STRING "")
 set(EXTRA_LIBRARIES udev CACHE STRING "")

--- a/support/docker/files/configuration-fedora-29.cmake
+++ b/support/docker/files/configuration-fedora-29.cmake
@@ -1,3 +1,3 @@
 include(${CMAKE_CURRENT_LIST_DIR}/configuration-fedora-base.cmake)
-set(CPACK_RPM_PACKAGE_REQUIRES "qt5-qtbase >= 5.5.0, fxload, CCfits, libdc1394" CACHE STRING "")
+set(CPACK_RPM_PACKAGE_REQUIRES "qt5-qtbase >= 5.5.0, CCfits, libdc1394" CACHE STRING "")
 

--- a/support/docker/files/configuration-fedora-30.cmake
+++ b/support/docker/files/configuration-fedora-30.cmake
@@ -1,3 +1,3 @@
 include(${CMAKE_CURRENT_LIST_DIR}/configuration-fedora-base.cmake)
-set(CPACK_RPM_PACKAGE_REQUIRES "qt5-qtbase >= 5.5.0, fxload, CCfits, libdc1394" CACHE STRING "")
+set(CPACK_RPM_PACKAGE_REQUIRES "qt5-qtbase >= 5.5.0, CCfits, libdc1394" CACHE STRING "")
 

--- a/support/docker/files/configuration-fedora-31.cmake
+++ b/support/docker/files/configuration-fedora-31.cmake
@@ -1,3 +1,3 @@
 include(${CMAKE_CURRENT_LIST_DIR}/configuration-fedora-base.cmake)
-set(CPACK_RPM_PACKAGE_REQUIRES "qt5-qtbase >= 5.5.0, fxload, CCfits, libdc1394" CACHE STRING "")
+set(CPACK_RPM_PACKAGE_REQUIRES "qt5-qtbase >= 5.5.0, CCfits, libdc1394" CACHE STRING "")
 

--- a/support/docker/files/configuration-ubuntu-16.04.cmake
+++ b/support/docker/files/configuration-ubuntu-16.04.cmake
@@ -1,4 +1,4 @@
 include(${CMAKE_CURRENT_LIST_DIR}/configuration-debian-base.cmake)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libusb-1.0-0, libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc2.4v5, libopencv-core2.4v5, libopencv-highgui2.4v5, fxload, libccfits0v5" CACHE STRING "")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc2.4v5, libopencv-core2.4v5, libopencv-highgui2.4v5, libccfits0v5" CACHE STRING "")
 set(EXTRA_LIBRARIES udev CACHE STRING "")
 

--- a/support/docker/files/configuration-ubuntu-18.04.cmake
+++ b/support/docker/files/configuration-ubuntu-18.04.cmake
@@ -1,4 +1,4 @@
 include(${CMAKE_CURRENT_LIST_DIR}/configuration-debian-base.cmake)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libusb-1.0-0, libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc3.2, libopencv-core3.2, libopencv-highgui3.2, fxload, libccfits0v5" CACHE STRING "")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc3.2, libopencv-core3.2, libopencv-highgui3.2, libccfits0v5" CACHE STRING "")
 set(EXTRA_LIBRARIES udev CACHE STRING "")
 

--- a/support/docker/files/configuration-ubuntu-19.04.cmake
+++ b/support/docker/files/configuration-ubuntu-19.04.cmake
@@ -1,5 +1,5 @@
 include(${CMAKE_CURRENT_LIST_DIR}/configuration-debian-base.cmake)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libusb-1.0-0, libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc3.2, libopencv-core3.2, libopencv-highgui3.2, fxload, libccfits0v5" CACHE STRING "")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5gui5 (>= 5.5.0), libqt5opengl5 (>= 5.5.0), libqt5network5 (>= 5.5.0), libqt5widgets5 (>= 5.5.0), libopencv-imgproc3.2, libopencv-core3.2, libopencv-highgui3.2, libccfits0v5" CACHE STRING "")
 set(EXTRA_LIBRARIES udev CACHE STRING "")
 
 


### PR DESCRIPTION
Debian packages were missing several opencv modules and Qt Qml library, adding them to this release.