### PR TITLE
Correctly save and restore window size, docks position and toolbars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__
 .kdev4*
 .directory
 CMakeLists.txt.user
+compile_commands.json
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ enable_testing()
 project(PlanetaryImager)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(MAJOR_VERSION 0)
 set(MINOR_VERSION 7)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(PlanetaryImager_GUI_SRCS planetaryimager_mainwindow.cpp planetaryimager_mainwindow.ui resources/resources.qrc)
+set(PlanetaryImager_GUI_SRCS planetaryimager_mainwindow.cpp mainwindowwidgets.cpp planetaryimager_mainwindow.ui resources/resources.qrc)
 set(PlanetaryImager_SRCS planetaryimager_main.cpp ${PlanetaryImager_GUI_SRCS})
 
 

--- a/src/mainwindowwidgets.cpp
+++ b/src/mainwindowwidgets.cpp
@@ -43,18 +43,24 @@ DPTR_IMPL(MainWindowWidgets) {
     QAction *toolbars_separator;
     QList<QDockWidget*> docks;
     QList<QToolBar*> toolbars;
+    void add_menu_action(const char *text, function<void()> lambda_function);
 };
+
+void MainWindowWidgets::Private::add_menu_action(const char *text, function<void()> lambda_function) {
+    auto action = window_menu->addAction(QObject::tr(text));
+    QObject::connect(action, &QAction::triggered, main_window, lambda_function);
+}
 
 MainWindowWidgets::MainWindowWidgets(QMainWindow *main_window, QMenu *windowMenu, Configuration &configuration) : dptr(main_window, windowMenu, configuration, !configuration.widgets_setup_first_run()) {
     configuration.set_widgets_setup_first_run(true);
     windowMenu->addSection(QObject::tr("Panels"));
     d->docks_separator = windowMenu->addSeparator();
-    windowMenu->addAction(QObject::tr("Show All"), main_window, [this]{
+    d->add_menu_action("Show All", [this]{
         for(auto dock: d->docks) {
             dock->show();
         }
     });
-    windowMenu->addAction(QObject::tr("Hide All"), main_window, [this] {
+    d->add_menu_action("Hide All", [this] {
         for(auto dock: d->docks) {
             dock->hide();
         }
@@ -62,12 +68,12 @@ MainWindowWidgets::MainWindowWidgets(QMainWindow *main_window, QMenu *windowMenu
 
     windowMenu->addSection(QObject::tr("Toolbars"));
     d->toolbars_separator = windowMenu->addSeparator();
-    windowMenu->addAction(QObject::tr("Show All"), main_window, [this]{
+    d->add_menu_action("Show All", [this]{
         for(auto toolbar: d->toolbars) {
             toolbar->show();
         }
     });
-    windowMenu->addAction(QObject::tr("Hide All"), main_window, [this] {
+    d->add_menu_action("Hide All", [this] {
         for(auto toolbar: d->toolbars) {
             toolbar->hide();
         }

--- a/src/mainwindowwidgets.cpp
+++ b/src/mainwindowwidgets.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2019  Marco Gulino <marco@gulinux.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#include "mainwindowwidgets.h"
+#include "commons/configuration.h"
+#include <QMainWindow>
+#include <QList>
+#include <QDockWidget>
+#include <QAction>
+#include <QMenu>
+#include <QDebug>
+#include <QVariantMap>
+#include <QVariantList>
+#include <QJsonDocument>
+#include <QToolBar>
+#include <algorithm>
+
+using namespace std;
+
+DPTR_IMPL(MainWindowWidgets) {
+    QMainWindow *main_window;
+    QMenu *window_menu;
+    Configuration &configuration;
+    bool is_first_run;
+
+    QAction *docks_separator;
+    QAction *toolbars_separator;
+    QList<QDockWidget*> docks;
+    QList<QToolBar*> toolbars;
+};
+
+MainWindowWidgets::MainWindowWidgets(QMainWindow *main_window, QMenu *windowMenu, Configuration &configuration) : dptr(main_window, windowMenu, configuration, !configuration.widgets_setup_first_run()) {
+    configuration.set_widgets_setup_first_run(true);
+    windowMenu->addSection(QObject::tr("Panels"));
+    d->docks_separator = windowMenu->addSeparator();
+    windowMenu->addAction(QObject::tr("Show All"), main_window, [this]{
+        for(auto dock: d->docks) {
+            dock->show();
+        }
+    });
+    windowMenu->addAction(QObject::tr("Hide All"), main_window, [this] {
+        for(auto dock: d->docks) {
+            dock->hide();
+        }
+    });
+
+    windowMenu->addSection(QObject::tr("Toolbars"));
+    d->toolbars_separator = windowMenu->addSeparator();
+    windowMenu->addAction(QObject::tr("Show All"), main_window, [this]{
+        for(auto toolbar: d->toolbars) {
+            toolbar->show();
+        }
+    });
+    windowMenu->addAction(QObject::tr("Hide All"), main_window, [this] {
+        for(auto toolbar: d->toolbars) {
+            toolbar->hide();
+        }
+    });
+
+}
+
+MainWindowWidgets::~MainWindowWidgets() {
+}
+
+
+void MainWindowWidgets::save() {
+    d->configuration.set_dock_status(d->main_window->saveState());
+}
+
+void MainWindowWidgets::load() {
+    d->main_window->restoreState(d->configuration.dock_status());
+    for(auto dock: d->docks) {
+        d->main_window->restoreDockWidget(dock);
+    }
+}
+
+void MainWindowWidgets::add_dock(QDockWidget *widget) {
+    if(d->is_first_run && !d->docks.isEmpty()) {
+        d->main_window->tabifyDockWidget(d->docks.first(), widget);
+    }
+
+    d->window_menu->insertAction(d->docks_separator, widget->toggleViewAction());
+    d->docks.push_back({widget});
+}
+
+void MainWindowWidgets::add_toolbar(QToolBar *toolbar, bool add_to_main_window) {
+    d->toolbars.push_back(toolbar);
+    if(add_to_main_window) {
+        d->main_window->addToolBar(toolbar);
+    }
+    d->window_menu->insertAction(d->toolbars_separator, toolbar->toggleViewAction());
+}

--- a/src/mainwindowwidgets.h
+++ b/src/mainwindowwidgets.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019  Marco Gulino <marco@gulinux.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "dptr.h"
+#include "commons/fwd.h"
+
+FWD_PTR(MainWindowWidgets)
+FWD(QMainWindow)
+FWD(QDockWidget)
+FWD(QToolBar)
+FWD(QMenu)
+FWD(Configuration)
+
+class MainWindowWidgets {
+public:
+    MainWindowWidgets(QMainWindow *main_window, QMenu *windowMenu, Configuration &configuration);
+    ~MainWindowWidgets();
+    void add_dock(QDockWidget *widget);
+    void add_toolbar(QToolBar *toolbar, bool add_to_main_window = false);
+    void save();
+    void load();
+private:
+    DPTR
+};

--- a/src/planetaryimager_mainwindow.cpp
+++ b/src/planetaryimager_mainwindow.cpp
@@ -83,7 +83,7 @@ DPTR_IMPL(PlanetaryImagerMainWindow) {
   unique_ptr<Ui::PlanetaryImagerMainWindow> ui;
   Imager *imager = nullptr;
   void rescan_devices();
-  void saveState();
+  void saveWindowGeometry();
 
   StatusBarInfoWidget *statusbar_info_widget;
   shared_ptr<DisplayImage> displayImage;
@@ -123,7 +123,7 @@ PlanetaryImagerMainWindow::~PlanetaryImagerMainWindow()
   d->planetaryImager->quit();
 }
 
-void PlanetaryImagerMainWindow::Private::saveState()
+void PlanetaryImagerMainWindow::Private::saveWindowGeometry()
 {
   planetaryImager->configuration().set_main_window_geometry(q->saveGeometry());
 }
@@ -330,8 +330,8 @@ void PlanetaryImagerMainWindow::showEvent(QShowEvent *event)
 void PlanetaryImagerMainWindow::closeEvent(QCloseEvent* event)
 {
   d->main_window_widgets->save();
+  d->saveWindowGeometry();
   QMainWindow::closeEvent(event);
-  saveState();
   emit quit();
 }
 

--- a/src/planetaryimager_mainwindow.h
+++ b/src/planetaryimager_mainwindow.h
@@ -57,6 +57,7 @@ public slots:
   void notify(const QDateTime &when, MessagesLogger::Type notification_type, const QString &title, const QString &message);
 protected:
   void closeEvent(QCloseEvent *event) override;
+  void showEvent(QShowEvent *event) override;
 signals:
   void quit();
   void imagerChanged();

--- a/src/planetaryimager_mainwindow.ui
+++ b/src/planetaryimager_mainwindow.ui
@@ -26,7 +26,7 @@
      <x>0</x>
      <y>0</y>
      <width>997</width>
-     <height>30</height>
+     <height>27</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuDevice">
@@ -45,18 +45,6 @@
     <addaction name="action_devices_rescan"/>
     <addaction name="menu_device_load"/>
     <addaction name="actionDisconnect"/>
-   </widget>
-   <widget class="QMenu" name="menuPanels">
-    <property name="title">
-     <string>Pa&amp;nels</string>
-    </property>
-    <addaction name="separator"/>
-    <addaction name="actionChip_Info"/>
-    <addaction name="actionCamera_Settings"/>
-    <addaction name="actionRecording"/>
-    <addaction name="actionHistogram"/>
-    <addaction name="actionHide_all"/>
-    <addaction name="actionShow_all"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -84,11 +72,16 @@
     <addaction name="actionAbout_Qt"/>
     <addaction name="actionQuit"/>
    </widget>
+   <widget class="QMenu" name="menuWindow">
+    <property name="title">
+     <string>Window</string>
+    </property>
+   </widget>
+   <addaction name="menuPlanetary_Imager"/>
    <addaction name="menuDevice"/>
-   <addaction name="menuPanels"/>
    <addaction name="menuView"/>
    <addaction name="menuROI"/>
-   <addaction name="menuPlanetary_Imager"/>
+   <addaction name="menuWindow"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <widget class="QDockWidget" name="chipInfoWidget">
@@ -134,7 +127,7 @@
           <x>0</x>
           <y>0</y>
           <width>80</width>
-          <height>162</height>
+          <height>165</height>
          </rect>
         </property>
        </widget>


### PR DESCRIPTION
Window geometry and state management was implementing incorrectly, leading to toolbars and panels being hidden on application restart.

This release fixes the behaviour, also refactoring a bit the code in an external class.