### PR TITLE
ASI183 visualization fix

### DIFF
--- a/src/commons/configuration.cpp
+++ b/src/commons/configuration.cpp
@@ -97,7 +97,6 @@ define_setting(max_display_fps, int, 30)
 define_setting(max_display_fps_recording, int, 15)
 define_setting(limit_fps, bool, true)
 define_setting(debayer, bool, true)
-define_setting(opengl, bool, true)
 define_setting(limit_fps_recording, bool, true)
 
 define_setting_enum(recording_limit_type, Configuration::RecordingLimit, Configuration::FramesNumber)

--- a/src/commons/configuration.h
+++ b/src/commons/configuration.h
@@ -41,7 +41,6 @@ public:
     declare_setting(limit_fps_recording, bool)
     declare_setting(debayer, bool)
     declare_setting(limit_fps, bool)
-    declare_setting(opengl, bool)
     
     declare_setting(buffered_output, bool )
     declare_setting(max_memory_usage, long long )

--- a/src/planetaryimager_mainwindow.cpp
+++ b/src/planetaryimager_mainwindow.cpp
@@ -163,15 +163,6 @@ PlanetaryImagerMainWindow::PlanetaryImagerMainWindow(
     d->ui->image->layout()->setMargin(0);
     d->ui->image->layout()->setSpacing(0);
     d->ui->image->layout()->addWidget(d->image_widget = new ZoomableImage(false));
-#ifdef HAVE_QT5_OPENGL // TODO: make configuration item
-    if(d->planetaryImager->configuration().opengl())
-    {
-      if (!QGLFormat::hasOpenGL())
-          qWarning() << "Window system does not support OpenGL.";
-      else
-          d->image_widget->setOpenGL();
-    }
-#endif
     d->image_widget->scene()->setBackgroundBrush(QBrush{Qt::black, Qt::Dense4Pattern});
     connect(d->image_widget, &ZoomableImage::zoomLevelChanged, d->statusbar_info_widget, &StatusBarInfoWidget::zoom);
     d->statusbar_info_widget->zoom(d->image_widget->zoomLevel());

--- a/src/widgets/configurationdialog.cpp
+++ b/src/widgets/configurationdialog.cpp
@@ -43,16 +43,10 @@ ConfigurationDialog::~ConfigurationDialog()
 
 ConfigurationDialog::ConfigurationDialog(Configuration &configuration, QWidget* parent) : QDialog(parent), dptr(configuration, this)
 {
-    static bool original_opengl_setting = d->configuration.opengl();
     d->ui.reset(new Ui::ConfigurationDialog);
     d->ui->setupUi(this);
-#ifndef HAVE_QT5_OPENGL
-    d->ui->opengl->hide();
-#endif
     connect(d->ui->debayer, &QCheckBox::toggled, bind(&Configuration::set_debayer, &d->configuration, _1));
-    connect(d->ui->opengl, &QCheckBox::toggled, bind(&Configuration::set_opengl, &d->configuration, _1));
     d->ui->debayer->setChecked(d->configuration.debayer());
-    d->ui->opengl->setChecked(d->configuration.opengl());
     d->ui->pauseShouldStopRecordingTimeout->setChecked(d->configuration.recording_pause_stops_timer());
     connect(d->ui->pauseShouldStopRecordingTimeout, &QCheckBox::toggled, bind(&Configuration::set_recording_pause_stops_timer, &d->configuration, _1));
     
@@ -174,11 +168,6 @@ ConfigurationDialog::ConfigurationDialog(Configuration &configuration, QWidget* 
     }
     d->ui->video_codec->setCurrentIndex(d->ui->video_codec->findData(d->configuration.video_codec()));
     connect(d->ui->video_codec, F_PTR(QComboBox, activated, int), [=](int index){ d->configuration.set_video_codec(d->ui->video_codec->itemData(index).toString()); });
-    connect(this, &QDialog::accepted, [this] {
-      if(original_opengl_setting != d->configuration.opengl()) {
-        QMessageBox::information(this, tr("Restart required"), tr("You changed the OpenGL setting. Please restart PlanetaryImage for this change to take effect"));
-      }
-    });
 
     d->ui->pixelDataEndianess->addItem("camera default", static_cast<int>(Configuration::CaptureEndianess::CameraDefault));
     d->ui->pixelDataEndianess->addItem("little-endian",  static_cast<int>(Configuration::CaptureEndianess::Little));

--- a/src/widgets/configurationdialog.ui
+++ b/src/widgets/configurationdialog.ui
@@ -27,7 +27,7 @@
    <item row="1" column="0">
     <widget class="QTabWidget" name="configurationTab">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -40,16 +40,17 @@
           <string>Image Display</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="enable_fps_limit_recording">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>1</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
+          <item row="2" column="2">
+           <widget class="QLabel" name="label_16">
             <property name="text">
-             <string>Set FPS limit while recording</string>
+             <string>FPS</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="3">
+           <widget class="QCheckBox" name="debayer">
+            <property name="text">
+             <string>Debayer images (colour camera only in raw mode)</string>
             </property>
            </widget>
           </item>
@@ -57,32 +58,6 @@
            <widget class="QLabel" name="label_15">
             <property name="text">
              <string>FPS</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="enable_fps_limit">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>1</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Set FPS limit while not recording</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QSpinBox" name="fps_limit">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>1</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimum">
-             <number>1</number>
             </property>
            </widget>
           </item>
@@ -99,14 +74,46 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
-           <widget class="QLabel" name="label_16">
-            <property name="text">
-             <string>FPS</string>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="fps_limit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>1</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimum">
+             <number>1</number>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="enable_fps_limit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>1</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Set FPS limit while not recording</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="enable_fps_limit_recording">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>1</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Set FPS limit while recording</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
            <spacer name="verticalSpacer_3">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -118,20 +125,6 @@
              </size>
             </property>
            </spacer>
-          </item>
-          <item row="0" column="0" colspan="3">
-           <widget class="QCheckBox" name="debayer">
-            <property name="text">
-             <string>Debayer images (colour camera only in raw mode)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="3">
-           <widget class="QCheckBox" name="opengl">
-            <property name="text">
-             <string>Use OpenGL rendering (requires restart)</string>
-            </property>
-           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
Fix visualization issue on ASI183MM/MC (and possibly other high resolution ASI cameras) where image is always black in preview window by disabling opengl rendering (which didn't seem to improve performances as much as expected, AND to cause rendering issues).