### PR TITLE
Quiet expected error cases

### DIFF
--- a/src/drivers/v4l2/v4l2device.cpp
+++ b/src/drivers/v4l2/v4l2device.cpp
@@ -93,13 +93,14 @@ void V4L2Device::__ioctl(uint64_t ctl, void* data, const QString& errorLabel) co
     //qDebug() << "IOCTL RUN: %1 with result %2"_q % d->ioctl_names.value(ctl, "%1"_q % ctl) % r;
 }
 
-int V4L2Device::__xioctl(uint64_t ctl, void* data, const QString& errorLabel) const
+int V4L2Device::__xioctl(uint64_t ctl, void* data, const QString &errorLabel, int ok_errno) const
 {
   try {
     this->ioctl(ctl, data, errorLabel);
     return 0;
   } catch(const V4L2Exception &e) {
-    qWarning() << e.what();
+    if (errno != ok_errno)
+      qWarning() << e.what();
     return -1;
   }
 }

--- a/src/drivers/v4l2/v4l2device.h
+++ b/src/drivers/v4l2/v4l2device.h
@@ -33,11 +33,17 @@ public:
   inline operator bool() const;
   int descriptor() const;
   
-  template<typename T> void ioctl(uint64_t ctl, T *data, const QString &errorLabel = {}) const { return __ioctl(ctl, reinterpret_cast<void*>(data), errorLabel); }
-  template<typename T> int xioctl(uint64_t ctl, T *data, const QString &errorLabel = {}) const { return __xioctl(ctl, reinterpret_cast<void*>(data), errorLabel); }
+  template<typename T> void ioctl(uint64_t ctl, T *data, const QString &errorLabel = {}) const {
+    return __ioctl(ctl, reinterpret_cast<void*>(data), errorLabel);
+  }
+
+  template<typename T> int xioctl(uint64_t ctl, T *data, const QString &errorLabel = {}, int ok_errno = 0) const {
+    return __xioctl(ctl, reinterpret_cast<void*>(data), errorLabel, ok_errno);
+  }
+
 private:
   void __ioctl(uint64_t ctl, void *data, const QString &errorLabel) const;
-  int __xioctl(uint64_t ctl, void *data, const QString &errorLabel) const;
+  int __xioctl(uint64_t ctl, void *data, const QString &errorLabel, int ok_errno) const;
   DPTR
 };
 

--- a/src/drivers/v4l2/v4l2imagingworker.cpp
+++ b/src/drivers/v4l2/v4l2imagingworker.cpp
@@ -102,9 +102,10 @@ void V4L2ImagingWorker::Private::adjust_framerate()
     fps_s.height = format.fmt.pix.height;
     fps_s.pixel_format = format.fmt.pix.pixelformat;
     qDebug() << "scanning for fps with pixel format " << FOURCC2QS(fps_s.pixel_format);
-    for(fps_s.index = 0; device->xioctl(VIDIOC_ENUM_FRAMEINTERVALS, &fps_s) >= 0; fps_s.index++) {
+    while (device->xioctl(VIDIOC_ENUM_FRAMEINTERVALS, &fps_s, {}, EINVAL) >= 0) {
       qDebug() << "found fps: " << fps_s;
       rates.push_back(fps_s);
+      fps_s.index++;
     }
     auto ratio = [=](const v4l2_frmivalenum &a) { return static_cast<double>(a.discrete.numerator)/static_cast<double>(a.discrete.denominator); };
     sort(begin(rates), end(rates), [&](const v4l2_frmivalenum &a, const v4l2_frmivalenum &b){ return ratio(a) < ratio(b);} );


### PR DESCRIPTION
Quiets down these messages:

```
 WARNING - int V4L2Device::__xioctl(uint64_t, void*, const QString&) const V4L2 error (-1) Invalid argument (code: 22) on querying resolutions ($checkoutpath/PlanetaryImager/src/drivers/v4l2/v4l2device.cpp:92)
 WARNING - int V4L2Device::__xioctl(uint64_t, void*, const QString&) const V4L2 error (-1) Invalid argument (code: 22) on querying resolutions ($checkoutpath/PlanetaryImager/src/drivers/v4l2/v4l2device.cpp:92)
 WARNING - int V4L2Device::__xioctl(uint64_t, void*, const QString&) const V4L2 error (-1) Invalid argument (code: 22) on ioctl VIDIOC_ENUM_FMT ($checkoutpath/PlanetaryImager/src/drivers/v4l2/v4l2device.cpp:92)
 WARNING - int V4L2Device::__xioctl(uint64_t, void*, const QString&) const V4L2 error (-1) Invalid argument (code: 22) on ioctl VIDIOC_ENUM_FRAMEINTERVALS ($checkoutpath/PlanetaryImager/src/drivers/v4l2/v4l2device.cpp:92)
```