### PR TITLE
Unlock mutex before destroying it.

### DIFF
--- a/src/drivers/imager.cpp
+++ b/src/drivers/imager.cpp
@@ -136,6 +136,7 @@ void Imager::wait_for(const std::shared_ptr<QWaitCondition>& wait_condition) con
   QMutex wait_mutex;
   wait_mutex.lock();
   wait_condition->wait(&wait_mutex);
+  wait_mutex.unlock();
 }
 
 


### PR DESCRIPTION
QWaitCondition.wait restores mutex to the original state.

Fixes:
```
 WARNING -  QMutex: destroying locked mutex
```
on each camera control change.