### PR TITLE
Fix crash when drawing histogram.

### DIFF
--- a/src/image_handlers/frontend/histLib.cpp
+++ b/src/image_handlers/frontend/histLib.cpp
@@ -441,7 +441,7 @@ void CHistLib::DrawHistBar(Mat& HistImage, unsigned BinCount)
       mHistImageBorder + mSpread * BinCount,
       mHistImageBorder + mHistImageHeight),
     mHistAxisColor,
-    0);
+    1);
 
   // Label initial bin
   putText(


### PR DESCRIPTION
Manifests as:
```
terminate called after throwing an instance of 'cv::Exception'
  what():  OpenCV(4.2.0) ../modules/imgproc/src/drawing.cpp:1811: error: (-215:Assertion failed) 0 < thickness && thickness <= MAX_THICKNESS in function 'line'
```